### PR TITLE
Two suggested changes to the tidy apply task

### DIFF
--- a/templates/tidy_apply.epp
+++ b/templates/tidy_apply.epp
@@ -1,4 +1,4 @@
 <%- | String $output_dir,
       String $tidy_age,
 | -%>
-/opt/puppetlabs/puppet/bin/puppet apply -e " tidy { '<%= $output_dir %>' : age => '<%= $tidy_age %>', recurse => 1 } "
+/opt/puppetlabs/puppet/bin/puppet apply -e " tidy { '<%= $output_dir %>' : age => '<%= $tidy_age %>', recurse => 1, type => 'mtime' } "

--- a/templates/tidy_apply.epp
+++ b/templates/tidy_apply.epp
@@ -1,4 +1,4 @@
 <%- | String $output_dir,
       String $tidy_age,
 | -%>
-puppet apply -e " tidy { '<%= $output_dir %>' : age => '<%= $tidy_age %>', recurse => 1 } "
+/opt/puppetlabs/puppet/bin/puppet apply -e " tidy { '<%= $output_dir %>' : age => '<%= $tidy_age %>', recurse => 1 } "


### PR DESCRIPTION
1) Tidy defaults to atime.  Maybe this should use mtime?
2) Fully path puppet apply (this is a PE-only module so it makes sense to use the PE path; doing so avoids finding any other puppet binary that may come first in the path).  This doesn't cause problems, but I spent some time looking for another puppet before I tried stat'ing the files that should have been tidy'ed.