### PR TITLE
Swap out puppet apply tidy for find commands in cron

### DIFF
--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -5,7 +5,7 @@ define pe_metric_curl_cron_jobs::pe_metric (
   String                    $metrics_type  = $title,
   Array[String]             $hosts         = [ '127.0.0.1' ],
   String                    $cron_minute   = '*/5',
-  String                    $tidy_age      = '3d',
+  Integer                   $tidy_age      = 3,
 ) {
 
   $metrics_output_dir = "${output_dir}/${metrics_type}"
@@ -34,7 +34,7 @@ define pe_metric_curl_cron_jobs::pe_metric (
 
   cron { "${metrics_type}_metrics_tidy" :
     ensure  => $metric_ensure,
-    command => epp("pe_metric_curl_cron_jobs/tidy_apply.epp",
+    command => epp("pe_metric_curl_cron_jobs/find_cron.epp",
                   { 'output_dir' => $metrics_output_dir,
                     'tidy_age'   => $tidy_age,
                   }),

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -5,7 +5,7 @@ define pe_metric_curl_cron_jobs::pe_metric (
   String                    $metrics_type  = $title,
   Array[String]             $hosts         = [ '127.0.0.1' ],
   String                    $cron_minute   = '*/5',
-  Integer                   $tidy_age      = 3,
+  Integer                   $retention_days = 3,
 ) {
 
   $metrics_output_dir = "${output_dir}/${metrics_type}"
@@ -35,8 +35,8 @@ define pe_metric_curl_cron_jobs::pe_metric (
   cron { "${metrics_type}_metrics_tidy" :
     ensure  => $metric_ensure,
     command => epp("pe_metric_curl_cron_jobs/find_cron.epp",
-                  { 'output_dir' => $metrics_output_dir,
-                    'tidy_age'   => $tidy_age,
+                  { 'output_dir'     => $metrics_output_dir,
+                    'retention_days' => $retention_days,
                   }),
     user    => 'root',
     hour    => '2',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "npwalker/pe_metric_curl_cron_jobs",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "author": "npwalker",
   "summary": "A Module for setting up cron jobs to curl metrics from PE components",
   "license": "Apache-2.0",

--- a/templates/find_cron.epp
+++ b/templates/find_cron.epp
@@ -1,0 +1,4 @@
+<%- | String $output_dir,
+      Integer $tidy_age,
+| -%>
+find '<%= $output_dir %>' -type f -mtime <%= $tidy_age %> -delete -print

--- a/templates/find_cron.epp
+++ b/templates/find_cron.epp
@@ -1,4 +1,4 @@
-<%- | String $output_dir,
-      Integer $tidy_age,
+<%- | String  $output_dir,
+      Integer $retention_days,
 | -%>
-find '<%= $output_dir %>' -type f -mtime <%= $tidy_age %> -delete -print
+find '<%= $output_dir %>' -type f -mtime <%= $retention_days %> -delete -print

--- a/templates/tidy_apply.epp
+++ b/templates/tidy_apply.epp
@@ -1,4 +1,0 @@
-<%- | String $output_dir,
-      String $tidy_age,
-| -%>
-/opt/puppetlabs/puppet/bin/puppet apply -e " tidy { '<%= $output_dir %>' : age => '<%= $tidy_age %>', recurse => 1, type => 'mtime' } "


### PR DESCRIPTION
Change mechanisms for file expiry from "puppet apply tidy" to "find <dir> -mtime -delete".  With large numbers of files tidy resources can be computationally and io-expensive.