### PR TITLE
Add -s param to curl to prevent excess output

### DIFF
--- a/templates/puppet_server_metrics.sh.epp
+++ b/templates/puppet_server_metrics.sh.epp
@@ -3,5 +3,5 @@
 | -%>
 
 <% $hosts.each | $host | { -%>
-curl -k https://<%= $host %>:8140/status/v1/services?level=debug | python -m json.tool > <%= $output_dir %>/<%= $host %>-`date +'%m_%d_%y_%R'`.json
+curl -s -k https://<%= $host %>:8140/status/v1/services?level=debug | python -m json.tool > <%= $output_dir %>/<%= $host %>-`date +'%m_%d_%y_%R'`.json
 <% } -%>

--- a/templates/puppetdb_metrics.sh.epp
+++ b/templates/puppetdb_metrics.sh.epp
@@ -51,7 +51,7 @@
 -%>
 <% $hosts.each | $host | {
      $metrics_array.each | $metric | {
-       $curl_command = "curl -k https://${host}:8081/metrics/v1/mbeans/${metric['url']}"
+       $curl_command = "curl -s -k https://${host}:8081/metrics/v1/mbeans/${metric['url']}"
        $curl_certs   = "--cert /etc/puppetlabs/puppet/ssl/certs/${::clientcert}.pem --key /etc/puppetlabs/puppet/ssl/private_keys/${::clientcert}.pem --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem >> ${output_dir}/${metric['name']}${host}-`date +'%m_%d_%y_%R'`.json"
 -%>
 


### PR DESCRIPTION
Add -s param to curl to prevent excess output from the cron job, which sends lots of useless emails like:

```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
 70 23122   70 16227    0     0  14589      0  0:00:01  0:00:01 --:--:-- 14605
100 23122  100 23122    0     0  20785      0  0:00:01  0:00:01 --:--:-- 20811
```