### PR TITLE
Updated README.md to reflect version 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,93 +1,123 @@
 Table of Contents
 =================
 
-  * [How to use](#how-to-use)
-    * [Monolithic Install](#monolithic-install)
-    * [Split Install ( Running on the Master )](#split-install--running-on-the-master-)
-    * [Monolithic With Compile Masters ( Running on the MoM )](#monolithic-with-compile-masters--running-on-the-mom-)
-    * [Split With Compile Masters ( Running on the MoM )](#split-with-compile-masters--running-on-the-mom-)
-    * [Running on PE 3\.8](#running-on-pe-38)
-    * [Other Option](#other-option)
-  * [What do you get](#what-do-you-get)
-    * [Grepping for Metrics](#grepping-for-metrics)
-      * [Puppetserver](#puppetserver)
-      * [PuppetDB](#puppetdb)
+* [Table of Contents](#table-of-contents)
+* [How to use](#how-to-use)
+	 * [Monolithic Intall](#monolithic-intall)
+	 * [Split Install ( Running on the Master )](#split-install--running-on-the-master-)
+	 * [Monolithic With Compile Masters ( Running on the MoM )](#monolithic-with-compile-masters--running-on-the-mom-)
+	 * [Split With Compile Masters ( Running on the MoM )](#split-with-compile-masters--running-on-the-mom-)
+	 * [Running on PE 3.8](#running-on-pe-38)
+	 * [Temporary Install](#temporary-install)
+	 * [Other Option for Split Install](#other-option-for-split-install)
+* [What do you get](#what-do-you-get)
+  * [Grepping for Metrics](#grepping-for-metrics)
+    * [Puppetserver](#puppetserver)
+    * [PuppetDB](#puppetdb)
 
 # How to use
 
-```
-include pe_metric_curl_cron_jobs
-```
+Install the module with `puppet module install npwalker-pe_metric_curl_cron_jobs`.
 
-If you do not want to manage this long term and want to get it up and running quickly you can run it via puppet apply.
-
-## Monolithic Install
+## Monolithic Intall
+To start data collection on a monolithic installation add the following to the Puppet master's node definition in the *site.pp* or add the `pe_metric_curl_cron_jobs` class in the node classifier.
 
 ```
-cd /tmp;
-git clone https://github.com/npwalker/pe_metric_curl_cron_jobs;
-puppet apply -e "class { 'pe_metric_curl_cron_jobs': }" --modulepath .
+  include pe_metric_curl_cron_jobs
 ```
 
 ## Split Install ( Running on the Master )
+To start data collection on a split installation add the following to the Puppet master's node definition in the *site.pp* or add the `pe_metric_curl_cron_jobs` class in the node classifier.
 
 ```
-cd /tmp;
-git clone https://github.com/npwalker/pe_metric_curl_cron_jobs;
-puppet apply -e "class { 'pe_metric_curl_cron_jobs' : puppetdb_hosts => ['split-puppetdb.domain.com'] }" --modulepath .
+class { 'pe_metric_curl_cron_jobs':
+  puppetdb_hosts => ['split-puppetdb.domain.com']
+}
+
 ```
 
 ## Monolithic With Compile Masters ( Running on the MoM )
+To start data collection on a monolithic installation with compile masters add the following to the Puppet master's node definition in the *site.pp* or add the `pe_metric_curl_cron_jobs` class in the node classifier.
 
 ```
-cd /tmp;
-git clone https://github.com/npwalker/pe_metric_curl_cron_jobs;
-puppet apply -e "class { 'pe_metric_curl_cron_jobs' : puppet_server_hosts => ['compile-master-1.domain.com', 'compile-master-2.domain.com'] }" --modulepath .
+class { 'pe_metric_curl_cron_jobs':
+  puppet_server_hosts => [
+    'master-1.domain.com',
+    'compile-master-1.domain.com',
+    'compile-master-2.domain.com'
+  ]
+}
 ```
 
 ## Split With Compile Masters ( Running on the MoM )
+To start data collection on a split installation with compile masters add the following to the Puppet master's node definition in the *site.pp* or add the `pe_metric_curl_cron_jobs` class in the node classifier.
 
 ```
-cd /tmp;
-git clone https://github.com/npwalker/pe_metric_curl_cron_jobs;
-puppet apply -e "class { 'pe_metric_curl_cron_jobs' : puppetdb_hosts => ['split-puppetdb.domain.com'], puppet_server_hosts => ['compile-master-1.domain.com', 'compile-master-2.domain.com'] }" --modulepath .
+class { 'pe_metric_curl_cron_jobs':
+  puppetdb_hosts => ['split-puppetdb.domain.com'],
+  puppet_server_hosts => [
+    'master-1.domain.com',
+    'compile-master-1.domain.com',
+    'compile-master-2.domain.com'
+  ]
+}
 ```
 
 ## Running on PE 3.8
 
-You can still use this module on PE 3.8 although you have to run it with the future parser and you want to use `/opt/puppet` instead of `/opt/puppetlabs`.
+You can still use this module on PE 3.8 although you have to run it with the future parser and you want to use `/opt/puppet` instead of `/opt/puppetlabs`. If the [future parser](https://docs.puppet.com/puppet/3.8/experiments_future.html) is enabled in the environment or globally, the following can be put in the site.pp.
+
+```
+class { 'pe_metric_curl_cron_jobs':
+  output_dir => '/opt/puppet/pe_metric_curl_cron_jobs'
+}
+```
+
+The module can be run in a one off run if the future parser is not enabled in the environment.
 
 ```
 cd /tmp;
 git clone https://github.com/npwalker/pe_metric_curl_cron_jobs;
-puppet apply -e "class { 'pe_metric_curl_cron_jobs' : output_dir => '/opt/puppet/pe_metric_curl_cron_jobs' }"  --modulepath . --parser=future
+puppet apply -e "class { 'pe_metric_curl_cron_jobs' : output_dir => '/opt/puppet/pe_metric_curl_cron_jobs' }"  --modulepath ".:$(puppet config print modulepath)" --parser=future
 ```
 
-Refer to the other examples if you want to change other parameters.
+If you do not want to manage this long term and want to get it up and running quickly you can run it via puppet apply. Make sure the puppetlabs-stdlib module is installed. Refer to the other examples if you want to change other parameters.
 
-## Other Option
+## Temporary Install
 
-This option puts metrics on each individual node so I don't think it's as good as having centrally gathered metrics but you can also install the module on each individual node.  If you install on a compile master you can set `puppetdb_metrics_ensure` to `absent` and if you install on a puppetdb node then you can set `$puppet_server_metrics_ensure` to `absent`.
+The module installation is the best way to utilize this module, but it can be run on a one off basis with the following command.
+
+```
+cd /tmp;
+git clone https://github.com/npwalker/pe_metric_curl_cron_jobs;
+puppet apply -e "class { 'pe_metric_curl_cron_jobs': }" --modulepath ".:$(puppet config print modulepath)"
+```
+
+## Other Option for Split Install
+
+This option puts metrics on each individual node so I don't think it's as good as having centrally gathered metrics, but you can also install the module on each individual node.  If you install on a compile master you can set `puppetdb_metrics_ensure` to `absent` and if you install on a puppetdb node then you can set `$puppet_server_metrics_ensure` to `absent`.
 
 # What do you get
 
-By default the module tracks the metrics coming from the status endpoint on Puppetserver and the internal ActiveMQ metrics on PuppetDB.  
+By default the module tracks the metrics coming from the status endpoint on Puppetserver and the internal ActiveMQ metrics on PuppetDB.
 
 A new directory `/opt/puppetlabs/pe_metric_curl_cron_jobs` that looks like:
 
 ```
 /opt/puppetlabs/pe_metric_curl_cron_jobs/
 ├── puppetdb
-│   ├── 127.0.0.1-08_16_16_23:40.json
-│   └── 127.0.0.1-08_16_16_23:45.json
-│   └── 127.0.0.1-08_16_16_23:50.json
-├── puppet_server
-│   ├── 127.0.0.1-08_16_16_23:40.json
-│   ├── 127.0.0.1-08_16_16_23:45.json
-│   ├── 127.0.0.1-08_16_16_23:50.json
+│   └── 127.0.0.1
+│       ├── 20170314T205501Z.json
+│       ├── 20170314T205510Z.json
+│       └── 20170314T210001Z.json
+├── puppetserver
+│   └── 127.0.0.1
+│       ├── 20170314T205001Z.json
+│       ├── 20170314T205501Z.json
+│       └── 20170314T210001Z.json
 └── scripts
-    ├── puppetdb_metrics.sh
-    └── puppet_server_metrics.sh
+    ├── puppetdb_metrics
+    └── puppetserver_metrics
 ```
 
 New cronjobs:
@@ -95,14 +125,14 @@ New cronjobs:
 ```
 crontab -l
 ...
-# Puppet Name: puppet_server_metrics_collection
-*/5 * * * * /opt/puppetlabs/pe_metric_curl_cron_jobs/scripts/puppet_server_metrics.sh
-# Puppet Name: puppet_server_metrics_tidy
-* 2 * * * puppet apply -e " tidy { '/opt/puppetlabs/pe_metric_curl_cron_jobs/puppet_server' : age => '3d', recurse => 1 } "
+# Puppet Name: puppetserver_metrics_collection
+*/5 * * * * /opt/puppetlabs/pe_metric_curl_cron_jobs/scripts/puppetserver_metrics
+# Puppet Name: puppetserver_metrics_tidy
+* 2 * * * find '/opt/puppetlabs/pe_metric_curl_cron_jobs' -type f -mtime 3 -delete
 # Puppet Name: puppetdb_metrics_collection
-*/5 * * * * /opt/puppetlabs/pe_metric_curl_cron_jobs/scripts/puppetdb_metrics.sh
+*/5 * * * * /opt/puppetlabs/pe_metric_curl_cron_jobs/scripts/puppetdb_metrics
 # Puppet Name: puppetdb_metrics_tidy
-* 2 * * * puppet apply -e " tidy { '/opt/puppetlabs/pe_metric_curl_cron_jobs/puppetdb' : age => '3d', recurse => 1 } "
+* 2 * * * find '/opt/puppetlabs/pe_metric_curl_cron_jobs' -type f -mtime 3 -delete
 ```
 
 ## Grepping for Metrics
@@ -110,7 +140,7 @@ crontab -l
 You can get useful information with a grep like the one below run from inside of the directory containing the metrics files.
 
 ```
-grep <metric_name> 127.0.0.1-*
+grep <metric_name> ./127.0.0.1/*.json
 ```
 
 ### Puppetserver
@@ -118,11 +148,11 @@ grep <metric_name> 127.0.0.1-*
 Example output:
 
 ```
-grep average-free-jrubies 127.0.0.1-*
-127.0.0.1-08_15_16_10:55.json:                    "average-free-jrubies": 3.6687597774999556,
-127.0.0.1-08_15_16_11:00.json:                    "average-free-jrubies": 4.4209186472147248,
-127.0.0.1-08_15_16_11:05.json:                    "average-free-jrubies": 3.610399319630555,
-127.0.0.1-08_15_16_11:10.json:                    "average-free-jrubies": 4.9845629308522383,
+grep average-free-jrubies puppetserver/127.0.0.1/*.json
+puppetserver/127.0.0.1/20170314T204501Z.json:                "average-free-jrubies": 0.9999535595280031,
+puppetserver/127.0.0.1/20170314T205001Z.json:                "average-free-jrubies": 0.995494318690345,
+puppetserver/127.0.0.1/20170314T205501Z.json:                "average-free-jrubies": 0.8035181730040821,
+puppetserver/127.0.0.1/20170314T210001Z.json:                "average-free-jrubies": 0.9978172841156308,
 ```
 
 ### PuppetDB
@@ -130,25 +160,29 @@ grep average-free-jrubies 127.0.0.1-*
 Example output:
 
 ```
-grep QueueSize 127.0.0.1-*
-127.0.0.1-08_16_16_23:40.json:  "QueueSize" : 0,
-127.0.0.1-08_16_16_23:45.json:  "QueueSize" : 0,
+grep QueueSize puppetdb/127.0.0.1/*.json
+puppetdb/127.0.0.1/20170314T205501Z.json:          "QueueSize": 0,
+puppetdb/127.0.0.1/20170314T205510Z.json:          "QueueSize": 0,
+puppetdb/127.0.0.1/20170314T210001Z.json:          "QueueSize": 0,
 ```
 
 ```
-grep CursorMemoryUsage 127.0.0.1-*
-127.0.0.1-08_16_16_23:40.json:  "CursorMemoryUsage" : 0,
-127.0.0.1-08_16_16_23:45.json:  "CursorMemoryUsage" : 0,
+grep CursorMemoryUsage puppetdb/127.0.0.1/*.json
+puppetdb/127.0.0.1/20170314T205501Z.json:          "CursorMemoryUsage": 0,
+puppetdb/127.0.0.1/20170314T205510Z.json:          "CursorMemoryUsage": 0,
+puppetdb/127.0.0.1/20170314T210001Z.json:          "CursorMemoryUsage": 0,
 ```
 
 ```
-grep CursorFull 127.0.0.1-*
-127.0.0.1-08_16_16_23:40.json:  "CursorFull" : false,
-127.0.0.1-08_16_16_23:45.json:  "CursorFull" : false,
+grep CursorFull puppetdb/127.0.0.1/*.json
+puppetdb/127.0.0.1/20170314T205501Z.json:          "CursorFull": false,
+puppetdb/127.0.0.1/20170314T205510Z.json:          "CursorFull": false,
+puppetdb/127.0.0.1/20170314T210001Z.json:          "CursorFull": false,
 ```
 
 ```
-grep CursorPercentUsage 127.0.0.1-*
-127.0.0.1-08_16_16_23:40.json:  "CursorPercentUsage" : 0,
-127.0.0.1-08_16_16_23:45.json:  "CursorPercentUsage" : 0,
+grep CursorPercentUsage puppetdb/127.0.0.1/*.json
+puppetdb/127.0.0.1/20170314T205501Z.json:          "CursorPercentUsage": 0,
+puppetdb/127.0.0.1/20170314T205510Z.json:          "CursorPercentUsage": 0,
+puppetdb/127.0.0.1/20170314T210001Z.json:          "CursorPercentUsage": 0,
 ```

--- a/README.md
+++ b/README.md
@@ -1,85 +1,130 @@
 Table of Contents
 =================
 
-* [Table of Contents](#table-of-contents)
-* [How to use](#how-to-use)
-	 * [Monolithic Intall](#monolithic-intall)
-	 * [Split Install ( Running on the Master )](#split-install--running-on-the-master-)
-	 * [Monolithic With Compile Masters ( Running on the MoM )](#monolithic-with-compile-masters--running-on-the-mom-)
-	 * [Split With Compile Masters ( Running on the MoM )](#split-with-compile-masters--running-on-the-mom-)
-	 * [Running on PE 3.8](#running-on-pe-38)
-	 * [Temporary Install](#temporary-install)
-	 * [Other Option for Split Install](#other-option-for-split-install)
-* [What do you get](#what-do-you-get)
-  * [Grepping for Metrics](#grepping-for-metrics)
-    * [Puppetserver](#puppetserver)
-    * [PuppetDB](#puppetdb)
+  * [How to use](#how-to-use)
+    * [Monolithic Install](#monolithic-install)
+      * [Hiera data Example](#hiera-data-example)
+      * [Class Definition](#class-definition)
+    * [Split Install ( Running on the Master )](#split-install--running-on-the-master-)
+      * [Hiera data Example](#hiera-data-example-1)
+      * [Class Definition Example](#class-definition-example)
+    * [Monolithic With Compile Masters ( Running on the MoM )](#monolithic-with-compile-masters--running-on-the-mom-)
+      * [Hiera data Example](#hiera-data-example-2)
+      * [Class Definition Example](#class-definition-example-1)
+    * [Split With Compile Masters ( Running on the MoM )](#split-with-compile-masters--running-on-the-mom-)
+      * [Hiera data Example](#hiera-data-example-3)
+      * [Class Definition Example](#class-definition-example-2)
+    * [Running on PE 3\.8](#running-on-pe-38)
+    * [Temporary Install](#temporary-install)
+    * [Alternate Option for Multi\-node Metrics Collection](#alternate-option-for-multi-node-metrics-collection)
+  * [What do you get](#what-do-you-get)
+    * [Grepping for Metrics](#grepping-for-metrics)
+      * [Puppetserver](#puppetserver)
+      * [PuppetDB](#puppetdb)
 
 # How to use
 
-Install the module with `puppet module install npwalker-pe_metric_curl_cron_jobs`.
+Install the module with `puppet module install npwalker-pe_metric_curl_cron_jobs` or add it to your Puppetfile.
 
-## Monolithic Intall
-To start data collection on a monolithic installation add the following to the Puppet master's node definition in the *site.pp* or add the `pe_metric_curl_cron_jobs` class in the node classifier.
+To start data collection you will need to classify your puppet master with the `pe_metric_curl_cron_jobs` class using your preferred classification method.
 
-```
-  include pe_metric_curl_cron_jobs
-```
+The following examples show how to configure the parameters to work in different setups but we assume you will always classify on the node that is the CA master.  The preferred method is to `include` the module and then provide hiera
+data for the parameters.
+
+## Monolithic Install
+
+### Hiera data Example
+
+None needed for a monolithic install
+
+### Class Definition
+
+~~~
+include pe_metric_curl_cron_jobs
+~~~
 
 ## Split Install ( Running on the Master )
-To start data collection on a split installation add the following to the Puppet master's node definition in the *site.pp* or add the `pe_metric_curl_cron_jobs` class in the node classifier.
 
-```
+### Hiera data Example
+
+~~~
+pe_metric_curl_cron_jobs::puppetdb_hosts:
+ - 'split-puppetdb.domain.com'
+~~~
+
+### Class Definition Example
+
+~~~
 class { 'pe_metric_curl_cron_jobs':
   puppetdb_hosts => ['split-puppetdb.domain.com']
 }
-
-```
+~~~
 
 ## Monolithic With Compile Masters ( Running on the MoM )
-To start data collection on a monolithic installation with compile masters add the following to the Puppet master's node definition in the *site.pp* or add the `pe_metric_curl_cron_jobs` class in the node classifier.
 
-```
+### Hiera data Example
+
+~~~
+pe_metric_curl_cron_jobs::puppetserver_hosts:
+ - 'master-1.domain.com'
+ - 'compile-master-1.domain.com'
+ - 'compile-master-2.domain.com'
+~~~
+
+### Class Definition Example
+
+~~~
 class { 'pe_metric_curl_cron_jobs':
-  puppet_server_hosts => [
+  puppetserver_hosts => [
     'master-1.domain.com',
     'compile-master-1.domain.com',
     'compile-master-2.domain.com'
   ]
 }
-```
+~~~
 
 ## Split With Compile Masters ( Running on the MoM )
-To start data collection on a split installation with compile masters add the following to the Puppet master's node definition in the *site.pp* or add the `pe_metric_curl_cron_jobs` class in the node classifier.
 
-```
+### Hiera data Example
+
+~~~
+pe_metric_curl_cron_jobs::puppetdb_hosts:
+ - 'split-puppetdb.domain.com'
+pe_metric_curl_cron_jobs::puppetserver_hosts:
+ - 'master-1.domain.com'
+ - 'compile-master-1.domain.com'
+ - 'compile-master-2.domain.com'
+~~~
+
+### Class Definition Example
+
+~~~
 class { 'pe_metric_curl_cron_jobs':
   puppetdb_hosts => ['split-puppetdb.domain.com'],
-  puppet_server_hosts => [
+  puppetserver_hosts => [
     'master-1.domain.com',
     'compile-master-1.domain.com',
     'compile-master-2.domain.com'
   ]
 }
-```
+~~~
 
 ## Running on PE 3.8
 
 You can still use this module on PE 3.8 although you have to run it with the future parser and you want to use `/opt/puppet` instead of `/opt/puppetlabs`. If the [future parser](https://docs.puppet.com/puppet/3.8/experiments_future.html) is enabled in the environment or globally, the following can be put in the site.pp.
 
-```
+~~~
 class { 'pe_metric_curl_cron_jobs':
   output_dir => '/opt/puppet/pe_metric_curl_cron_jobs'
 }
-```
+~~~
 
 The module can be run in a one off run if the future parser is not enabled in the environment.
 
-```
-cd /tmp;
-git clone https://github.com/npwalker/pe_metric_curl_cron_jobs;
-puppet apply -e "class { 'pe_metric_curl_cron_jobs' : output_dir => '/opt/puppet/pe_metric_curl_cron_jobs' }"  --modulepath ".:$(puppet config print modulepath)" --parser=future
-```
+~~~
+puppet module install npwalker-pe_metric_curl_cron_jobs --modulepath /tmp;
+puppet apply -e "class { 'pe_metric_curl_cron_jobs' : output_dir => '/opt/puppet/pe_metric_curl_cron_jobs' }"  --modulepath /tmp --parser=future
+~~~
 
 If you do not want to manage this long term and want to get it up and running quickly you can run it via puppet apply. Make sure the puppetlabs-stdlib module is installed. Refer to the other examples if you want to change other parameters.
 
@@ -87,23 +132,27 @@ If you do not want to manage this long term and want to get it up and running qu
 
 The module installation is the best way to utilize this module, but it can be run on a one off basis with the following command.
 
-```
-cd /tmp;
-git clone https://github.com/npwalker/pe_metric_curl_cron_jobs;
-puppet apply -e "class { 'pe_metric_curl_cron_jobs': }" --modulepath ".:$(puppet config print modulepath)"
-```
+~~~
+puppet module install npwalker-pe_metric_curl_cron_jobs --modulepath /tmp;
+puppet apply -e "class { 'pe_metric_curl_cron_jobs': }" --modulepath /tmp;
+~~~
 
-## Other Option for Split Install
+## Alternate Option for Multi-node Metrics Collection
 
-This option puts metrics on each individual node so I don't think it's as good as having centrally gathered metrics, but you can also install the module on each individual node.  If you install on a compile master you can set `puppetdb_metrics_ensure` to `absent` and if you install on a puppetdb node then you can set `$puppet_server_metrics_ensure` to `absent`.
+This option puts metrics on each individual node instead of gathering metrics centrally on the CA master.  In order to do so, you would classify each of your PE infrastructure nodes with this module.  This option is discouraged but if
+for some reason you can't reach out across a network segment or some other reason you may still wish to have metrics.
+
+When you classify a compile master you would set `$puppetdb_metrics_ensure` to `absent`.
+
+When you classify a PuppetDB node you would set `$puppetserver_metrics_ensure` to `absent`.
 
 # What do you get
 
-By default the module tracks the metrics coming from the status endpoint on Puppetserver and the internal ActiveMQ metrics on PuppetDB.
+By default the module tracks the metrics coming from the status endpoint on Puppetserver and various curated metrics from PuppetDB.
 
 A new directory `/opt/puppetlabs/pe_metric_curl_cron_jobs` that looks like:
 
-```
+~~~
 /opt/puppetlabs/pe_metric_curl_cron_jobs/
 ├── puppetdb
 │   └── 127.0.0.1
@@ -118,11 +167,11 @@ A new directory `/opt/puppetlabs/pe_metric_curl_cron_jobs` that looks like:
 └── scripts
     ├── puppetdb_metrics
     └── puppetserver_metrics
-```
+~~~
 
 New cronjobs:
 
-```
+~~~
 crontab -l
 ...
 # Puppet Name: puppetserver_metrics_collection
@@ -133,56 +182,56 @@ crontab -l
 */5 * * * * /opt/puppetlabs/pe_metric_curl_cron_jobs/scripts/puppetdb_metrics
 # Puppet Name: puppetdb_metrics_tidy
 * 2 * * * find '/opt/puppetlabs/pe_metric_curl_cron_jobs' -type f -mtime 3 -delete
-```
+~~~
 
 ## Grepping for Metrics
 
 You can get useful information with a grep like the one below run from inside of the directory containing the metrics files.
 
-```
-grep <metric_name> ./127.0.0.1/*.json
-```
+~~~
+grep <metric_name> <service_name>/127.0.0.1/*.json
+~~~
 
 ### Puppetserver
 
 Example output:
 
-```
+~~~
 grep average-free-jrubies puppetserver/127.0.0.1/*.json
 puppetserver/127.0.0.1/20170314T204501Z.json:                "average-free-jrubies": 0.9999535595280031,
 puppetserver/127.0.0.1/20170314T205001Z.json:                "average-free-jrubies": 0.995494318690345,
 puppetserver/127.0.0.1/20170314T205501Z.json:                "average-free-jrubies": 0.8035181730040821,
 puppetserver/127.0.0.1/20170314T210001Z.json:                "average-free-jrubies": 0.9978172841156308,
-```
+~~~
 
 ### PuppetDB
 
 Example output:
 
-```
+~~~
 grep QueueSize puppetdb/127.0.0.1/*.json
 puppetdb/127.0.0.1/20170314T205501Z.json:          "QueueSize": 0,
 puppetdb/127.0.0.1/20170314T205510Z.json:          "QueueSize": 0,
 puppetdb/127.0.0.1/20170314T210001Z.json:          "QueueSize": 0,
-```
+~~~
 
-```
+~~~
 grep CursorMemoryUsage puppetdb/127.0.0.1/*.json
 puppetdb/127.0.0.1/20170314T205501Z.json:          "CursorMemoryUsage": 0,
 puppetdb/127.0.0.1/20170314T205510Z.json:          "CursorMemoryUsage": 0,
 puppetdb/127.0.0.1/20170314T210001Z.json:          "CursorMemoryUsage": 0,
-```
+~~~
 
-```
+~~~
 grep CursorFull puppetdb/127.0.0.1/*.json
 puppetdb/127.0.0.1/20170314T205501Z.json:          "CursorFull": false,
 puppetdb/127.0.0.1/20170314T205510Z.json:          "CursorFull": false,
 puppetdb/127.0.0.1/20170314T210001Z.json:          "CursorFull": false,
-```
+~~~
 
-```
+~~~
 grep CursorPercentUsage puppetdb/127.0.0.1/*.json
 puppetdb/127.0.0.1/20170314T205501Z.json:          "CursorPercentUsage": 0,
 puppetdb/127.0.0.1/20170314T205510Z.json:          "CursorPercentUsage": 0,
 puppetdb/127.0.0.1/20170314T210001Z.json:          "CursorPercentUsage": 0,
-```
+~~~


### PR DESCRIPTION
Fixes issue #8

Prior to this commit the *README.md* showed information about v2.x, which
is no longer accurate with v3.0.0. This update provides new output and
updated commands for the current state of the module in the *README.md*. 

Since there is a dependency on *puppetlabs-stdlib*, I added `".:$(puppet config print modulepath)"` as the module path for the puppet apply. This should hopefully exclude users from having to download the *puppetlabs-stdlib* module locally to */tmp*. I figure that most customers will have the *stdlib* module already installed, but the *README.md* can easily changed to show how to pull the *puppetlabs-stdlib* module into */tmp* instead if that is a better approach. 