### PR TITLE
Fix command queue metric in 2017 1

### DIFF
--- a/templates/puppetdb_metrics.epp
+++ b/templates/puppetdb_metrics.epp
@@ -42,27 +42,19 @@ METRICS = [
     'url'  => 'puppetlabs.puppetdb.mq%3Aname%3Dglobal.retried' },
   { 'name' => 'global_retry_counts',
     'url'  => 'puppetlabs.puppetdb.mq%3Aname%3Dglobal.retry-counts' },
-  { 'name' => 'global_retry_persistence_time',
-    'url'  => 'puppetlabs.puppetdb.mq%3Aname%3Dglobal.retry-persistence-time' },
 <% if versioncmp($::pe_server_version, '2016.4.0') >= 0 { -%>
   { 'name' => 'replace_catalog_retried',
     'url'  => 'puppetlabs.puppetdb.mq%3Aname%3Dreplace+catalog.9.retried' },
   { 'name' => 'replace_catalog_retry_counts',
     'url'  => 'puppetlabs.puppetdb.mq%3Aname%3Dreplace+catalog.9.retry-counts' },
-  { 'name' => 'replace_catalog_retry_persistence_time',
-    'url'  => 'puppetlabs.puppetdb.mq%3Aname%3Dreplace+catalog.9.retry-persistence-time' },
   { 'name' => 'replace_facts_retried',
     'url'  => 'puppetlabs.puppetdb.mq%3Aname%3Dreplace+facts.5.retried' },
   { 'name' => 'replace_facts_retry_counts',
     'url'  => 'puppetlabs.puppetdb.mq%3Aname%3Dreplace+facts.5.retry-counts' },
-  { 'name' => 'replace_facts_retry_persistence_time',
-    'url'  => 'puppetlabs.puppetdb.mq%3Aname%3Dreplace+facts.5.retry-persistence-time' },
   { 'name' => 'store_report_retried',
     'url'  => 'puppetlabs.puppetdb.mq%3Aname%3Dstore+report.8.retried' },
   { 'name' => 'store_reports_retry_counts',
     'url'  => 'puppetlabs.puppetdb.mq%3Aname%3Dstore+report.8.retry-counts' },
-  { 'name' => 'store_report_retry_persistence_time',
-    'url'  => 'puppetlabs.puppetdb.mq%3Aname%3Dstore+report.8.retry-persistence-time' },
 <% } -%>
 ]
 

--- a/templates/puppetdb_metrics.epp
+++ b/templates/puppetdb_metrics.epp
@@ -17,8 +17,13 @@ HOSTS = [
 ]
 
 METRICS = [
-  { 'name' => 'commands_queue',
+<% if versioncmp($::pe_server_version, '2017.1.0') >= 0 { -%>
+  { 'name' => 'command_queue_depth',
+    'url'  => 'puppetlabs.puppetdb.mq%3Aname%3Dglobal.depth' },
+<% } else { -%>
+  { 'name' => 'amq_metrics',
     'url'  => 'org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=puppetlabs.puppetdb.commands' },
+<% } -%>
   { 'name' => 'catalog_hash_miss',
     'url'  => 'puppetlabs.puppetdb.storage%3Aname%3Dcatalog-hash-miss-time' },
   { 'name' => 'catalog_hash_match',

--- a/templates/puppetdb_metrics.epp
+++ b/templates/puppetdb_metrics.epp
@@ -24,6 +24,10 @@ METRICS = [
   { 'name' => 'amq_metrics',
     'url'  => 'org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=puppetlabs.puppetdb.commands' },
 <% } -%>
+  { 'name' => 'command_processing_time',
+    'url'  => 'puppetlabs.puppetdb.mq:name=global.processing-time' },
+  { 'name' => 'command_processed',
+    'url'  => 'puppetlabs.puppetdb.mq:name=global.processed' },
   { 'name' => 'catalog_hash_miss',
     'url'  => 'puppetlabs.puppetdb.storage%3Aname%3Dcatalog-hash-miss-time' },
   { 'name' => 'catalog_hash_match',


### PR DESCRIPTION
This PR fixes the command queue metric in 2017.1 to use the new stockpile metric for command queue depth instead of the activemq metrics. 

It also adds in processing metrics which are useful in the PDB performance dashboard.  

This is a workaround to #9.  We should have better error handling but we shouldn't ask for the wrong metric endpoint either.  