### PR TITLE
Add cronjob to compress and remove files each day

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@ class pe_metric_curl_cron_jobs (
   # CURRENT API =================================
   String        $output_dir                    = '/opt/puppetlabs/pe_metric_curl_cron_jobs',
   Integer       $collection_frequency          = 5,
-  Integer       $retention_days                = 3,
+  Integer       $retention_days                = 90,
   String        $puppetserver_metrics_ensure   = pick($pe_metric_curl_cron_jobs::puppet_server_metrics_ensure, 'present'),
   Array[String] $puppetserver_hosts            = pick($pe_metric_curl_cron_jobs::puppet_server_hosts, [ '127.0.0.1' ]),
   Integer       $puppetserver_port             = 8140,

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -55,6 +55,7 @@ define pe_metric_curl_cron_jobs::pe_metric (
     ensure  => $metric_ensure,
     user    => 'root',
     hour    => '2',
+    minute  => '0',
     command => $metrics_tidy_script_path
   }
 

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -6,7 +6,7 @@ define pe_metric_curl_cron_jobs::pe_metric (
   String                    $metrics_type   = $title,
   Array[String]             $hosts          = [ '127.0.0.1' ],
   String                    $cron_minute    = '*/5',
-  Integer                   $retention_days = 3,
+  Integer                   $retention_days = 90,
   String                    $metric_script_template = 'tk_metrics.epp',
 ) {
 
@@ -44,6 +44,13 @@ define pe_metric_curl_cron_jobs::pe_metric (
     user    => 'root',
     hour    => '2',
     command => "find '${metrics_output_dir}' -type f -mtime ${retention_days} -delete",
+  }
+
+  cron { "${metrics_type}_metrics_tar" :
+    ensure  => $metric_ensure,
+    user    => 'root',
+    hour    => '1',
+    command => "export DIR='${metrics_output_dir}' ; find \"\$DIR\" -type f \! -name \"*.bz2\" > \"\$DIR.tmp\" ; xargs -a \"\$DIR.tmp\" tar -jcf \"\$DIR/${metrics_type}-$(date +%Y%m%d).tar.bz2\" 2>/dev/null ; xargs -a \"\$DIR.tmp\" rm ; rm \"\$DIR.tmp\"",
   }
 
   #Cleanup old .sh scripts

--- a/templates/tidy_cron.epp
+++ b/templates/tidy_cron.epp
@@ -11,7 +11,8 @@ RETENTION_DAYS=<%= $retention_days %>;
 find "$DIR" -type f -mtime $RETENTION_DAYS -delete
 
 #compress files
-find "$DIR" -type f ! -name "*.bz2" > "$DIR.tmp";
+cd "$DIR"
+find . -type f ! -name "*.bz2" > "$DIR.tmp";
 xargs -a "$DIR.tmp" tar -jcf "$DIR/$METRICS_TYPE-$(date +%Y.%m.%d.%H.%M.%S).tar.bz2" 2>/dev/null;
 xargs -a "$DIR.tmp" rm ;
 rm "$DIR.tmp";

--- a/templates/tidy_cron.epp
+++ b/templates/tidy_cron.epp
@@ -12,6 +12,6 @@ find "$DIR" -type f -mtime $RETENTION_DAYS -delete
 
 #compress files
 find "$DIR" -type f ! -name "*.bz2" > "$DIR.tmp";
-xargs -a "$DIR.tmp" tar -jcf "$DIR/$METRICS_TYPE-$(date +%Y%m%d).tar.bz2" 2>/dev/null;
+xargs -a "$DIR.tmp" tar -jcf "$DIR/$METRICS_TYPE-$(date +%Y.%m.%d.%H.%M.%S).tar.bz2" 2>/dev/null;
 xargs -a "$DIR.tmp" rm ;
 rm "$DIR.tmp";

--- a/templates/tidy_cron.epp
+++ b/templates/tidy_cron.epp
@@ -1,0 +1,17 @@
+<%- | String  $metrics_output_dir,
+      String  $metrics_type,
+      Integer $retention_days,
+| -%>
+#!/bin/sh
+DIR='<%= $metrics_output_dir %>';
+METRICS_TYPE='<%= $metrics_type %>';
+RETENTION_DAYS=<%= $retention_days %>;
+
+#delete files past retention days
+find "$DIR" -type f -mtime $RETENTION_DAYS -delete
+
+#compress files
+find "$DIR" -type f ! -name "*.bz2" > "$DIR.tmp";
+xargs -a "$DIR.tmp" tar -jcf "$DIR/$METRICS_TYPE-$(date +%Y%m%d).tar.bz2" 2>/dev/null;
+xargs -a "$DIR.tmp" rm ;
+rm "$DIR.tmp";


### PR DESCRIPTION
Prior to this commit, all json files were stored in text format, which consumed a great deal of disk space.  This adds a new cronjob per metrics_type that will tar and bzip2 the files each day, then remove them.  The dramatic disk space savings allows the retention rate to be extended to 90 days.