### PR TITLE
Make tidy cron not delete scripts

### DIFF
--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -43,7 +43,7 @@ define pe_metric_curl_cron_jobs::pe_metric (
     ensure  => $metric_ensure,
     user    => 'root',
     hour    => '2',
-    command => "find '${output_dir}' -type f -mtime ${retention_days} -delete",
+    command => "find '${metrics_output_dir}' -type f -mtime ${retention_days} -delete",
   }
 
   #Cleanup old .sh scripts


### PR DESCRIPTION
Prior to this commit, the tidy process would also delete the scripts themselves, requiring them to be re-created by Puppet on the next agent run.  This update changes the base directory of the find to the metrics directory.