### PR TITLE
Stagger tidy cron jobs to avoid a CPU spike

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Each component has two cron jobs created for it.
 - A cron job to gather the metrics
   - Runs every 5 minutes
 - A cron job to delete metrics past the rentention_days and compress metrics
-  - Runs daily at 2AM
+  - Runs at randomly selected time between midnight and 3AM
 
 Example:
 

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -54,8 +54,8 @@ define pe_metric_curl_cron_jobs::pe_metric (
   cron { "${metrics_type}_metrics_tidy" :
     ensure  => $metric_ensure,
     user    => 'root',
-    hour    => '2',
-    minute  => '0',
+    hour    => fqdn_rand(3,  $metrics_type ),
+    minute  => (5 * fqdn_rand(11, $metrics_type )),
     command => $metrics_tidy_script_path
   }
 


### PR DESCRIPTION
Prior to this commit, all tidy cron jobs ran at exactly 2AM. This
would presumably cause a noticeable spike in CPU because compressing
files takes CPU.

After this commit, we move to a random time between midnight and
3AM.