### PR TITLE
Add a --print commandline argument to the metrics scripts

### DIFF
--- a/templates/activemq_metrics.epp
+++ b/templates/activemq_metrics.epp
@@ -10,9 +10,18 @@ require "net/https"
 require "json"
 require "uri"
 require 'time'
+require 'optparse'
+
+METRICS_TYPE = "<%= $metrics_type %>"
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: #{METRICS_TYPE}_metrics [options]"
+
+  opts.on('-p', '--print', 'Print to stdout') { |v| options[:print] = true }
+end.parse!
 
 OUTPUT_DIR = "<%= $output_dir %>"
-METRICS_TYPE = "<%= $metrics_type %>"
 
 HOSTS = [
 <% $hosts.each |$host| { -%>
@@ -127,11 +136,16 @@ HOSTS.each do |host|
     dataset['servers'][hostkey][METRICS_TYPE]['api-query-start'] = timestamp.utc.iso8601
     dataset['servers'][hostkey][METRICS_TYPE]['api-query-duration'] = Time.now - timestamp
 
+    json_dataset = JSON.pretty_generate(dataset)
+
     Dir.chdir(OUTPUT_DIR) do
       Dir.mkdir(host) unless File.exist?(host)
       File.open(File.join(host, filename), 'w') do |file|
-        file.write(JSON.pretty_generate(dataset))
+        file.write(json_dataset)
       end
+    end
+    if options[:print] == true then
+      STDOUT.write(json_dataset)
     end
   rescue Exception => e
     STDERR.puts "Error getting metrics for #{host}: #{e}"

--- a/templates/tk_metrics.epp
+++ b/templates/tk_metrics.epp
@@ -10,9 +10,18 @@ require "net/https"
 require "json"
 require "uri"
 require 'time'
+require 'optparse'
+
+METRICS_TYPE = "<%= $metrics_type %>"
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: #{METRICS_TYPE}_metrics [options]"
+
+  opts.on('-p', '--print', 'Print to stdout') { |v| options[:print] = true }
+end.parse!
 
 OUTPUT_DIR = "<%= $output_dir %>"
-METRICS_TYPE = "<%= $metrics_type %>"
 
 HOSTS = [
 <% $hosts.each |$host| { -%>
@@ -66,11 +75,16 @@ HOSTS.each do |host|
     dataset['servers'][hostkey][METRICS_TYPE]['api-query-start'] = timestamp.utc.iso8601
     dataset['servers'][hostkey][METRICS_TYPE]['api-query-duration'] = Time.now - timestamp
 
+    json_dataset = JSON.pretty_generate(dataset)
+
     Dir.chdir(OUTPUT_DIR) do
       Dir.mkdir(host) unless File.exist?(host)
       File.open(File.join(host, filename), 'w') do |file|
-        file.write(JSON.pretty_generate(dataset))
+        file.write(json_dataset)
       end
+    end
+    if options[:print] == true then
+      STDOUT.write(json_dataset)
     end
   end
 end


### PR DESCRIPTION
Prior to this PR, the tk_metrics and activemq_metrics scripts only wrote their own output file.

After this PR, you can pass a cmdline argument to have the output written to stdout in addition to its output file.  This allows for integrations with other tools that can read the output from stdout.