### PR TITLE
Add a --no-file argument to allow disabling storing a file of metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Minor Release 4.2.0
+
+## Improvements
+ - Add a `--no-file` command line argument to the metrics scripts
+   - This allows for integrations to optionally not write metrics to a file
+   - [PR #27](https://github.com/npwalker/pe_metric_curl_cron_jobs/pull/27)
+
 # Minor Release 4.1.0
 
 ## Improvements
@@ -7,7 +14,7 @@
    - This allows for integrations with other tools that can read the output from stdout.
    - [PR #24](https://github.com/npwalker/pe_metric_curl_cron_jobs/pull/24)
  - Move script configuration into a YAML file
-   - Allow the metrics scripts to be stored as static files instead of templates 
+   - Allow the metrics scripts to be stored as static files instead of templates
    - [PR #25](https://github.com/npwalker/pe_metric_curl_cron_jobs/pull/25)
 
 # Major Release 4.0.0

--- a/files/amq_metrics
+++ b/files/amq_metrics
@@ -12,6 +12,7 @@ OptionParser.new do |opts|
   opts.banner = "Usage: tk_metrics [options]"
 
   opts.on('-p', '--print', 'Print to stdout') { |v| options[:print] = true }
+  opts.on('-f', '--[no-]file', 'Store output to a file') { |v| options[:file] = v }
   opts.on('-m [TYPE]', '--metrics_type [TYPE]', 'Type of metric to collect') { |v| options[:metrics_type] = v }
 end.parse!
 
@@ -99,10 +100,12 @@ HOSTS.each do |host|
 
     json_dataset = JSON.pretty_generate(dataset)
 
-    Dir.chdir(OUTPUT_DIR) do
-      Dir.mkdir(host) unless File.exist?(host)
-      File.open(File.join(host, filename), 'w') do |file|
-        file.write(json_dataset)
+    if options[:file] != false then
+      Dir.chdir(OUTPUT_DIR) do
+        Dir.mkdir(host) unless File.exist?(host)
+        File.open(File.join(host, filename), 'w') do |file|
+          file.write(json_dataset)
+        end
       end
     end
     if options[:print] == true then

--- a/files/amq_metrics
+++ b/files/amq_metrics
@@ -9,7 +9,7 @@ require 'yaml'
 
 options = {}
 OptionParser.new do |opts|
-  opts.banner = "Usage: tk_metrics [options]"
+  opts.banner = "Usage: amq_metrics [options]"
 
   opts.on('-p', '--print', 'Print to stdout') { |v| options[:print] = true }
   opts.on('-f', '--[no-]file', 'Store output to a file') { |v| options[:file] = v }

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -12,6 +12,7 @@ OptionParser.new do |opts|
   opts.banner = "Usage: tk_metrics [options]"
 
   opts.on('-p', '--print', 'Print to stdout') { |v| options[:print] = true }
+  opts.on('-f', '--[no-]file', 'Store output to a file') { |v| options[:file] = v }
   opts.on('-m [TYPE]', '--metrics_type [TYPE]', 'Type of metric to collect') { |v| options[:metrics_type] = v }
 end.parse!
 
@@ -103,10 +104,12 @@ HOSTS.each do |host|
 
     json_dataset = JSON.pretty_generate(dataset)
 
-    Dir.chdir(OUTPUT_DIR) do
-      Dir.mkdir(host) unless File.exist?(host)
-      File.open(File.join(host, filename), 'w') do |file|
-        file.write(json_dataset)
+    if options[:file] != false then
+      Dir.chdir(OUTPUT_DIR) do
+        Dir.mkdir(host) unless File.exist?(host)
+        File.open(File.join(host, filename), 'w') do |file|
+          file.write(json_dataset)
+        end
       end
     end
     if options[:print] == true then

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "npwalker/pe_metric_curl_cron_jobs",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "author": "npwalker",
   "summary": "A Puppet module for gathering metrics from PE components",
   "license": "Apache-2.0",


### PR DESCRIPTION
Prior to this commit, whenever the script ran it always saved output
to a file.  You could additionally use the --print argument to get the
output on STDOUT for use by another program or script.  However, if you
wanted to run the script often, say every 10 seconds, you'd produce a
lot of files and potentially use too much disk space.

After this commit, you can run the script with `--no-file` and the
script will not save the output to the file.  This is intended to be
used only by a setup outside of the cron jobs provided by this module.
The cron jobs should always save output on their regular schedule but
we want to provide an option to not store the file for use cases that
run the script a lot via another mechanism.