### PR TITLE
Allow not writing to a file by implementing an --output-dir argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Minor Release 4.2.0
+
+## Improvements
+ - Allow not saving a metrics file
+   - Add a `--output-dir` CLI argument to metrics scripts which tells the script
+   where to save metrics output to.
+   - If `--output-dir` is not specified then no file is saved
+ - Metrics scripts print to STDOUT by default
+   - Use `--no-print` to silence output to STDOUT
+
 # Minor Release 4.1.0
 
 ## Improvements
@@ -7,7 +17,7 @@
    - This allows for integrations with other tools that can read the output from stdout.
    - [PR #24](https://github.com/npwalker/pe_metric_curl_cron_jobs/pull/24)
  - Move script configuration into a YAML file
-   - Allow the metrics scripts to be stored as static files instead of templates 
+   - Allow the metrics scripts to be stored as static files instead of templates
    - [PR #25](https://github.com/npwalker/pe_metric_curl_cron_jobs/pull/25)
 
 # Major Release 4.0.0

--- a/files/amq_metrics
+++ b/files/amq_metrics
@@ -11,7 +11,7 @@ options = {}
 OptionParser.new do |opts|
   opts.banner = "Usage: tk_metrics [options]"
 
-  opts.on('-p', '--print', 'Print to stdout') { |v| options[:print] = true }
+  opts.on('-p', '--[no-]print', 'Print to stdout') { |p| options[:print] = p }
   opts.on('-m [TYPE]', '--metrics_type [TYPE]', 'Type of metric to collect') { |v| options[:metrics_type] = v }
   opts.on('-o [DIR]', '--output-dir [DIR]', 'Directory to save output to') { |o| options[:output_dir] = o }
 end.parse!
@@ -108,7 +108,7 @@ HOSTS.each do |host|
         end
       end
     end
-    if options[:print] == true then
+    if options[:print] != false then
       STDOUT.write(json_dataset)
     end
   rescue Exception => e

--- a/files/amq_metrics
+++ b/files/amq_metrics
@@ -9,7 +9,7 @@ require 'yaml'
 
 options = {}
 OptionParser.new do |opts|
-  opts.banner = "Usage: tk_metrics [options]"
+  opts.banner = "Usage: amq_metrics [options]"
 
   opts.on('-p', '--[no-]print', 'Print to stdout') { |p| options[:print] = p }
   opts.on('-m [TYPE]', '--metrics_type [TYPE]', 'Type of metric to collect') { |v| options[:metrics_type] = v }

--- a/files/amq_metrics
+++ b/files/amq_metrics
@@ -13,6 +13,7 @@ OptionParser.new do |opts|
 
   opts.on('-p', '--print', 'Print to stdout') { |v| options[:print] = true }
   opts.on('-m [TYPE]', '--metrics_type [TYPE]', 'Type of metric to collect') { |v| options[:metrics_type] = v }
+  opts.on('-o [DIR]', '--output-dir [DIR]', 'Directory to save output to') { |o| options[:output_dir] = o }
 end.parse!
 
 if options[:metrics_type].nil? then
@@ -23,7 +24,7 @@ end
 METRICS_TYPE = options[:metrics_type]
 config = YAML.load_file(File.join(File.dirname(File.expand_path(__FILE__)),"#{METRICS_TYPE}_config.yaml"))
 
-OUTPUT_DIR = config['output_dir']
+OUTPUT_DIR = options[:output_dir]
 HOSTS      = config['hosts']
 PORT       = config['metrics_port']
 METRICS    = config['additional_metrics']
@@ -99,10 +100,12 @@ HOSTS.each do |host|
 
     json_dataset = JSON.pretty_generate(dataset)
 
-    Dir.chdir(OUTPUT_DIR) do
-      Dir.mkdir(host) unless File.exist?(host)
-      File.open(File.join(host, filename), 'w') do |file|
-        file.write(json_dataset)
+    unless OUTPUT_DIR.nil? then
+      Dir.chdir(OUTPUT_DIR) do
+        Dir.mkdir(host) unless File.exist?(host)
+        File.open(File.join(host, filename), 'w') do |file|
+          file.write(json_dataset)
+        end
       end
     end
     if options[:print] == true then

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -13,6 +13,7 @@ OptionParser.new do |opts|
 
   opts.on('-p', '--print', 'Print to stdout') { |v| options[:print] = true }
   opts.on('-m [TYPE]', '--metrics_type [TYPE]', 'Type of metric to collect') { |v| options[:metrics_type] = v }
+  opts.on('-o [DIR]', '--output-dir [DIR]', 'Directory to save output to') { |o| options[:output_dir] = o }
 end.parse!
 
 if options[:metrics_type].nil? then
@@ -23,7 +24,7 @@ end
 METRICS_TYPE = options[:metrics_type]
 config = YAML.load_file(File.join(File.dirname(File.expand_path(__FILE__)),"#{METRICS_TYPE}_config.yaml"))
 
-OUTPUT_DIR = config['output_dir']
+OUTPUT_DIR = options[:output_dir]
 HOSTS      = config['hosts']
 PORT       = config['metrics_port']
 METRICS    = config['additional_metrics']
@@ -103,10 +104,12 @@ HOSTS.each do |host|
 
     json_dataset = JSON.pretty_generate(dataset)
 
-    Dir.chdir(OUTPUT_DIR) do
-      Dir.mkdir(host) unless File.exist?(host)
-      File.open(File.join(host, filename), 'w') do |file|
-        file.write(json_dataset)
+    unless OUTPUT_DIR.nil? then
+      Dir.chdir(OUTPUT_DIR) do
+        Dir.mkdir(host) unless File.exist?(host)
+        File.open(File.join(host, filename), 'w') do |file|
+          file.write(json_dataset)
+        end
       end
     end
     if options[:print] == true then

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -11,7 +11,7 @@ options = {}
 OptionParser.new do |opts|
   opts.banner = "Usage: tk_metrics [options]"
 
-  opts.on('-p', '--print', 'Print to stdout') { |v| options[:print] = true }
+  opts.on('-p', '--[no-]print', 'Print to stdout') { |p| options[:print] = p }
   opts.on('-m [TYPE]', '--metrics_type [TYPE]', 'Type of metric to collect') { |v| options[:metrics_type] = v }
   opts.on('-o [DIR]', '--output-dir [DIR]', 'Directory to save output to') { |o| options[:output_dir] = o }
 end.parse!
@@ -112,7 +112,7 @@ HOSTS.each do |host|
         end
       end
     end
-    if options[:print] == true then
+    if options[:print] != false then
       STDOUT.write(json_dataset)
     end
   end

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -21,7 +21,6 @@ define pe_metric_curl_cron_jobs::pe_metric (
   }
 
   $config_hash = {
-    'output_dir'         => $metrics_output_dir,
     'hosts'              => $hosts,
     'metrics_type'       => $metrics_type,
     'metrics_port'       => $metrics_port,
@@ -39,7 +38,7 @@ define pe_metric_curl_cron_jobs::pe_metric (
 
   cron { "${metrics_type}_metrics_collection" :
     ensure  => $metric_ensure,
-    command => "${script_file_name} --metrics_type ${metrics_type}",
+    command => "${script_file_name} --metrics_type ${metrics_type} --output-dir ${metrics_output_dir}",
     user    => 'root',
     minute  => $cron_minute,
   }

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -38,7 +38,7 @@ define pe_metric_curl_cron_jobs::pe_metric (
 
   cron { "${metrics_type}_metrics_collection" :
     ensure  => $metric_ensure,
-    command => "${script_file_name} --metrics_type ${metrics_type} --output-dir ${metrics_output_dir}",
+    command => "${script_file_name} --metrics_type ${metrics_type} --output-dir ${metrics_output_dir} --no-print",
     user    => 'root',
     minute  => $cron_minute,
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "npwalker/pe_metric_curl_cron_jobs",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "author": "npwalker",
   "summary": "A Puppet module for gathering metrics from PE components",
   "license": "Apache-2.0",


### PR DESCRIPTION
Prior to this PR 
 - You could only specify the output_dir from
the config file for the metric type you were calling.
 - We specified the output-dir in the config
file for each metric.
 - The default behavior of the metrics scripts was
to not print anything to STDOUT.  

After this PR, 
 - You can specify the output_dir from the CLI.
   - In addition, if you do not specify an `--output-dir` then output
will not be written to a file.
 - We specify the output-dir via CLI argument and
remove it from the config file by default.
 - The default behavior of the metrics scripts is
to print to STDOUT.  In order to silence the output you must specify
`--no-print`.
 - The cronjobs created now specify --no-print.  
