### PR TITLE
Use GET instead of POST for metrics on older PE versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Z Release 4.2.1
+
+## Bug Fixes:
+ - PE versions < 2016.2 now GET each metric individually instead of using a POST
+   - [PR #30](https://github.com/npwalker/pe_metric_curl_cron_jobs/pull/30)
+
 # Minor Release 4.2.0
 
 ## Improvements

--- a/files/amq_metrics
+++ b/files/amq_metrics
@@ -29,6 +29,7 @@ HOSTS      = config['hosts']
 PORT       = config['metrics_port']
 METRICS    = config['additional_metrics']
 CLIENTCERT = config['clientcert']
+PE_VERSION = config['pe_version']
 
 POST_DATA = METRICS.to_json
 

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -29,6 +29,7 @@ HOSTS      = config['hosts']
 PORT       = config['metrics_port']
 METRICS    = config['additional_metrics']
 CLIENTCERT = config['clientcert']
+PE_VERSION = config['pe_version']
 
 $error_array = []
 
@@ -82,18 +83,25 @@ HOSTS.each do |host|
     post_data = []
 
     unless METRICS.empty? then
-      METRICS.each do |metric|
-        post_data << metric['url']
-      end
+      if Gem::Version.new(PE_VERSION) < Gem::Version.new('2016.2.0') then
+        METRICS.each do |metric|
+          endpoint = "#{host_url}/metrics/v1/mbeans/#{metric['url']}"
+          dataset['servers'][hostkey][METRICS_TYPE][metric['name']] = get_endpoint(endpoint)
+        end
+      else
+        METRICS.each do |metric|
+          post_data << metric['url']
+        end
 
-      endpoint = "#{host_url}/metrics/v1/mbeans"
-      metrics_output = post_endpoint(endpoint, post_data.to_json)
+        endpoint = "#{host_url}/metrics/v1/mbeans"
+        metrics_output = post_endpoint(endpoint, post_data.to_json)
 
-      METRICS.each_index do |index|
-        metric_name = METRICS[index]['name']
-        metric_data = metrics_output[index]
+        METRICS.each_index do |index|
+          metric_name = METRICS[index]['name']
+          metric_data = metrics_output[index]
 
-        dataset['servers'][hostkey][METRICS_TYPE][metric_name] = metric_data
+          dataset['servers'][hostkey][METRICS_TYPE][metric_name] = metric_data
+        end
       end
     end
 

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -26,6 +26,7 @@ define pe_metric_curl_cron_jobs::pe_metric (
     'metrics_port'       => $metrics_port,
     'additional_metrics' => $additional_metrics,
     'clientcert'         => $::clientcert,
+    'pe_version'         => $facts['pe_server_version'],
   }
 
   file { "${scripts_dir}/${metrics_type}_config.yaml" :

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "npwalker/pe_metric_curl_cron_jobs",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "author": "npwalker",
   "summary": "A Puppet module for gathering metrics from PE components",
   "license": "Apache-2.0",


### PR DESCRIPTION
Prior to this commit, we always POSTed metrics to collect from PuppetDB.
Turns out that before PE 2016.2 we didn't support that.

After this commit, we grab each metric with a single GET from PuppetDB
for versions < 2016.2.  We still POST for versions that support it.

Fixes https://github.com/npwalker/pe_metric_curl_cron_jobs/issues/29