### PR TITLE
Fix retention script to delete really old files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Z Release 4.2.2
+
+## Bug Fixes:
+ - Tidy cron jobs would only delete metric files exactly retention_days away
+   - [PR #33](https://github.com/npwalker/pe_metric_curl_cron_jobs/pull/33)
+
 # Z Release 4.2.1
 
 ## Bug Fixes:

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "npwalker/pe_metric_curl_cron_jobs",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "author": "npwalker",
   "summary": "A Puppet module for gathering metrics from PE components",
   "license": "Apache-2.0",

--- a/templates/tidy_cron.epp
+++ b/templates/tidy_cron.epp
@@ -8,7 +8,7 @@ METRICS_TYPE='<%= $metrics_type %>';
 RETENTION_DAYS=<%= $retention_days %>;
 
 #delete files past retention days
-find "$DIR" -type f -mtime $RETENTION_DAYS -delete
+find "$DIR" -type f -ctime +$RETENTION_DAYS -delete
 
 #compress files
 cd "$DIR"


### PR DESCRIPTION
Prior to this commit, the find command to delete old files would
only delete files exactly $retention_days older than when the
command is run.  This means that if the script runs every day then
everything should be fine and no extra data is piling up.  However,
if the server is off or the cron does not run for any reason then
extra data will be left behind as it will be older than the
retention_days parameter.

After this commit, the find command will delete files older than
the retention days parameter instead of exactly as old as the
retention_days parameter.

We also switch to ctime instead of mtime beacuse we care about when
the files were created not when they were last modified.