### PR TITLE
Enable connecting to metrics without certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Minor Release 4.3.0
+
+## Improvements
+  - No longer pass certificates to connect to metrics endpoint
+    - [PR #34](https://github.com/npwalker/pe_metric_curl_cron_jobs/pull/34)
+
 # Z Release 4.2.2
 
 ## Bug Fixes:

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -37,9 +37,6 @@ def get_endpoint(url)
   uri  = URI.parse(url)
   http = Net::HTTP.new(uri.host, uri.port)
   http.use_ssl = true
-  http.cert = OpenSSL::X509::Certificate.new(File.read("/etc/puppetlabs/puppet/ssl/certs/#{CLIENTCERT}.pem"))
-  http.key  = OpenSSL::PKey::RSA.new(File.read("/etc/puppetlabs/puppet/ssl/private_keys/#{CLIENTCERT}.pem"))
-  http.ca_file = '/etc/puppetlabs/puppet/ssl/certs/ca.pem'
   http.verify_mode = OpenSSL::SSL::VERIFY_NONE
   data = JSON.parse(http.get(uri.request_uri).body)
 rescue Exception => e
@@ -51,9 +48,6 @@ def post_endpoint(url,post_data)
   uri  = URI.parse(url)
   http = Net::HTTP.new(uri.host, uri.port)
   http.use_ssl = true
-  http.cert = OpenSSL::X509::Certificate.new(File.read("/etc/puppetlabs/puppet/ssl/certs/#{CLIENTCERT}.pem"))
-  http.key  = OpenSSL::PKey::RSA.new(File.read("/etc/puppetlabs/puppet/ssl/private_keys/#{CLIENTCERT}.pem"))
-  http.ca_file = '/etc/puppetlabs/puppet/ssl/certs/ca.pem'
   http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
   request = Net::HTTP::Post.new(uri.request_uri)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "npwalker/pe_metric_curl_cron_jobs",
-  "version": "4.2.2",
+  "version": "4.3.0",
   "author": "npwalker",
   "summary": "A Puppet module for gathering metrics from PE components",
   "license": "Apache-2.0",


### PR DESCRIPTION
Prior to this commit, we used certificates to connect to the metrics
endpoints despite using SSL_VERIFY_NONE.

After this commit, we forgo the certificates so non-root users can easily
run the script.  