### PR TITLE
Allow communicating over http instead of https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Minor Release 4.4.0
+
+## Improvements
+  - Allow connecting over http instead of https for PuppetDB
+    - [PR #37](https://github.com/npwalker/pe_metric_curl_cron_jobs/pull/37)
+    - In order to use pass `--no-ssl` and `--metrics_port` to the tk_metrics script
+
 # Minor Release 4.3.0
 
 ## Improvements

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -14,6 +14,7 @@ OptionParser.new do |opts|
   opts.on('-p', '--[no-]print', 'Print to stdout') { |p| options[:print] = p }
   opts.on('-m [TYPE]', '--metrics_type [TYPE]', 'Type of metric to collect') { |v| options[:metrics_type] = v }
   opts.on('-o [DIR]', '--output-dir [DIR]', 'Directory to save output to') { |o| options[:output_dir] = o }
+  opts.on('--metrics_port [PORT]', 'The port the metrics service runs on') { |port| options[:metrics_port] = port }
 end.parse!
 
 if options[:metrics_type].nil? then
@@ -26,7 +27,7 @@ config = YAML.load_file(File.join(File.dirname(File.expand_path(__FILE__)),"#{ME
 
 OUTPUT_DIR = options[:output_dir]
 HOSTS      = config['hosts']
-PORT       = config['metrics_port']
+PORT       = options[:metrics_port] || config['metrics_port']
 METRICS    = config['additional_metrics']
 CLIENTCERT = config['clientcert']
 PE_VERSION = config['pe_version']

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -15,6 +15,7 @@ OptionParser.new do |opts|
   opts.on('-m [TYPE]', '--metrics_type [TYPE]', 'Type of metric to collect') { |v| options[:metrics_type] = v }
   opts.on('-o [DIR]', '--output-dir [DIR]', 'Directory to save output to') { |o| options[:output_dir] = o }
   opts.on('--metrics_port [PORT]', 'The port the metrics service runs on') { |port| options[:metrics_port] = port }
+  opts.on('--[no-]ssl', 'Whether or not to use SSL when gather metrics') { |ssl| options[:ssl] = ssl }
 end.parse!
 
 if options[:metrics_type].nil? then
@@ -43,20 +44,23 @@ PORT       = coalesce(options[:metrics_port], config['metrics_port'])
 METRICS    = config['additional_metrics']
 CLIENTCERT = config['clientcert']
 PE_VERSION = config['pe_version']
+SSL        = coalesce(options[:ssl], config['ssl'], true)
 
 $error_array = []
 
-def setup_connection(url)
+def setup_connection(url, ssl)
   uri  = URI.parse(url)
   http = Net::HTTP.new(uri.host, uri.port)
-  http.use_ssl = true
-  http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+  if ssl then
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+  end
 
   return http,uri
 end
 
-def get_endpoint(url)
-  http,uri = setup_connection(url)
+def get_endpoint(url,ssl)
+  http,uri = setup_connection(url,ssl)
 
   data = JSON.parse(http.get(uri.request_uri).body)
 rescue Exception => e
@@ -64,8 +68,8 @@ rescue Exception => e
     data = {}
 end
 
-def post_endpoint(url,post_data)
-  http,uri = setup_connection(url)
+def post_endpoint(url,post_data,ssl)
+  http,uri = setup_connection(url,ssl)
 
   request = Net::HTTP::Post.new(uri.request_uri)
   request.content_type = 'application/json'
@@ -77,15 +81,25 @@ rescue Exception => e
     data = {}
 end
 
-def get_status_endpoint(host, port)
-  host_url = "https://#{host}:#{port}"
+def generate_host_url(host, port, ssl)
+  if ssl then
+    protocol = 'https'
+  else
+    protocol = 'http'
+  end
 
-  status_endpoint = "#{host_url}/status/v1/services?level=debug"
-  status_output   = get_endpoint(status_endpoint)
+  host_url = "#{protocol}://#{host}:#{port}"
 end
 
-def bulk_retrieve_additional_metrics(host, port, metrics)
-  host_url = "https://#{host}:#{port}"
+def get_status_endpoint(host, port, ssl)
+  host_url = generate_host_url(host, port, ssl)
+
+  status_endpoint = "#{host_url}/status/v1/services?level=debug"
+  status_output   = get_endpoint(status_endpoint,ssl)
+end
+
+def bulk_retrieve_additional_metrics(host, port, metrics, ssl)
+  host_url = generate_host_url(host, port, ssl)
 
   post_data = []
   metrics.each do |metric|
@@ -93,7 +107,7 @@ def bulk_retrieve_additional_metrics(host, port, metrics)
   end
 
   endpoint = "#{host_url}/metrics/v1/mbeans"
-  metrics_output = post_endpoint(endpoint, post_data.to_json)
+  metrics_output = post_endpoint(endpoint, post_data.to_json, ssl)
   metrics_array = []
 
   metrics.each_index do |index|
@@ -107,24 +121,24 @@ def bulk_retrieve_additional_metrics(host, port, metrics)
   return metrics_array
 end
 
-def individually_retrieve_additional_metrics(host, port, metrics)
-  host_url = "https://#{host}:#{port}"
+def individually_retrieve_additional_metrics(host, port, metrics, ssl)
+  host_url = generate_host_url(host, port, ssl)
 
   metrics_array = []
   metrics.each do |metric|
     endpoint = URI.escape("#{host_url}/metrics/v1/mbeans/#{metric['url']}")
     metrics_array <<  { 'name' => metric['name'],
-                        'data' => get_endpoint(endpoint) }
+                        'data' => get_endpoint(endpoint, ssl) }
   end
 
   return metrics_array
 end
 
-def retrieve_additional_metrics(host,port,metrics,pe_version)
+def retrieve_additional_metrics(host,port,metrics,pe_version, ssl)
   if Gem::Version.new(pe_version) < Gem::Version.new('2016.2.0') then
-    metrics_array = individually_retrieve_additional_metrics(host, port, metrics)
+    metrics_array = individually_retrieve_additional_metrics(host, port, metrics, ssl)
   else
-    metrics_array = bulk_retrieve_additional_metrics(host, port, metrics)
+    metrics_array = bulk_retrieve_additional_metrics(host, port, metrics, ssl)
   end
 
   return metrics_array
@@ -138,11 +152,11 @@ HOSTS.each do |host|
     dataset = {'timestamp' => timestamp.utc.iso8601, 'servers' => {}}
     hostkey = host.gsub('.', '-')
 
-    status_output   = get_status_endpoint(host, PORT)
+    status_output   = get_status_endpoint(host, PORT, SSL)
     dataset['servers'][hostkey] = {METRICS_TYPE => status_output}
 
     unless METRICS.empty? then
-      metrics_array = retrieve_additional_metrics(host, PORT, METRICS, PE_VERSION)
+      metrics_array = retrieve_additional_metrics(host, PORT, METRICS, PE_VERSION, SSL)
 
       metrics_array.each do |metric_hash|
         metric_name = metric_hash['name']

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -125,8 +125,6 @@ HOSTS.each do |host|
     dataset = {'timestamp' => timestamp.utc.iso8601, 'servers' => {}}
     hostkey = host.gsub('.', '-')
 
-    host_url = "https://#{host}:#{PORT}"
-
     status_output   = get_status_endpoint(host, PORT)
     dataset['servers'][hostkey] = {METRICS_TYPE => status_output}
 

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -25,9 +25,21 @@ end
 METRICS_TYPE = options[:metrics_type]
 config = YAML.load_file(File.join(File.dirname(File.expand_path(__FILE__)),"#{METRICS_TYPE}_config.yaml"))
 
+def coalesce ( opt1, opt2, default=nil )
+  if opt1.nil? then
+    if opt2.nil? then
+      default
+    else
+      opt2
+    end
+  else
+    opt1
+  end
+end
+
 OUTPUT_DIR = options[:output_dir]
 HOSTS      = config['hosts']
-PORT       = options[:metrics_port] || config['metrics_port']
+PORT       = coalesce(options[:metrics_port], config['metrics_port'])
 METRICS    = config['additional_metrics']
 CLIENTCERT = config['clientcert']
 PE_VERSION = config['pe_version']

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -94,6 +94,19 @@ def bulk_retrieve_additional_metrics(host, port, metrics)
   return metrics_array
 end
 
+def individually_retrieve_additional_metrics(host, port, metrics)
+  host_url = "https://#{host}:#{port}"
+
+  metrics_array = []
+  metrics.each do |metric|
+    endpoint = "#{host_url}/metrics/v1/mbeans/#{metric['url']}"
+    metrics_array <<  { 'name' => metric['name'],
+                        'data' => get_endpoint(endpoint) }
+  end
+
+  return metrics_array
+end
+
 filename = Time.now.utc.strftime('%Y%m%dT%H%M%SZ') + '.json'
 
 HOSTS.each do |host|
@@ -109,9 +122,13 @@ HOSTS.each do |host|
 
     unless METRICS.empty? then
       if Gem::Version.new(PE_VERSION) < Gem::Version.new('2016.2.0') then
-        METRICS.each do |metric|
-          endpoint = "#{host_url}/metrics/v1/mbeans/#{metric['url']}"
-          dataset['servers'][hostkey][METRICS_TYPE][metric['name']] = get_endpoint(endpoint)
+        metrics_array = individually_retrieve_additional_metrics(host, PORT, METRICS)
+
+        metrics_array.each do |metric_hash|
+          metric_name = metric_hash['name']
+          metric_data = metric_hash['data']
+
+          dataset['servers'][hostkey][METRICS_TYPE][metric_name] = metric_data
         end
       else
         metrics_array = bulk_retrieve_additional_metrics(host, PORT, METRICS)

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -71,6 +71,29 @@ def get_status_endpoint(host, port)
   status_output   = get_endpoint(status_endpoint)
 end
 
+def bulk_retrieve_additional_metrics(host, port, metrics)
+  host_url = "https://#{host}:#{port}"
+
+  post_data = []
+  metrics.each do |metric|
+    post_data << metric['url']
+  end
+
+  endpoint = "#{host_url}/metrics/v1/mbeans"
+  metrics_output = post_endpoint(endpoint, post_data.to_json)
+  metrics_array = []
+
+  metrics.each_index do |index|
+    metric_name = metrics[index]['name']
+    metric_data = metrics_output[index]
+
+    metrics_array << { 'name' => metric_name,
+                       'data' => metric_data  }
+  end
+
+  return metrics_array
+end
+
 filename = Time.now.utc.strftime('%Y%m%dT%H%M%SZ') + '.json'
 
 HOSTS.each do |host|
@@ -84,8 +107,6 @@ HOSTS.each do |host|
     status_output   = get_status_endpoint(host, PORT)
     dataset['servers'][hostkey] = {METRICS_TYPE => status_output}
 
-    post_data = []
-
     unless METRICS.empty? then
       if Gem::Version.new(PE_VERSION) < Gem::Version.new('2016.2.0') then
         METRICS.each do |metric|
@@ -93,16 +114,11 @@ HOSTS.each do |host|
           dataset['servers'][hostkey][METRICS_TYPE][metric['name']] = get_endpoint(endpoint)
         end
       else
-        METRICS.each do |metric|
-          post_data << metric['url']
-        end
+        metrics_array = bulk_retrieve_additional_metrics(host, PORT, METRICS)
 
-        endpoint = "#{host_url}/metrics/v1/mbeans"
-        metrics_output = post_endpoint(endpoint, post_data.to_json)
-
-        METRICS.each_index do |index|
-          metric_name = METRICS[index]['name']
-          metric_data = metrics_output[index]
+        metrics_array.each do |metric_hash|
+          metric_name = metric_hash['name']
+          metric_data = metric_hash['data']
 
           dataset['servers'][hostkey][METRICS_TYPE][metric_name] = metric_data
         end

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -123,22 +123,14 @@ HOSTS.each do |host|
     unless METRICS.empty? then
       if Gem::Version.new(PE_VERSION) < Gem::Version.new('2016.2.0') then
         metrics_array = individually_retrieve_additional_metrics(host, PORT, METRICS)
-
-        metrics_array.each do |metric_hash|
-          metric_name = metric_hash['name']
-          metric_data = metric_hash['data']
-
-          dataset['servers'][hostkey][METRICS_TYPE][metric_name] = metric_data
-        end
       else
         metrics_array = bulk_retrieve_additional_metrics(host, PORT, METRICS)
+      end
+      metrics_array.each do |metric_hash|
+        metric_name = metric_hash['name']
+        metric_data = metric_hash['data']
 
-        metrics_array.each do |metric_hash|
-          metric_name = metric_hash['name']
-          metric_data = metric_hash['data']
-
-          dataset['servers'][hostkey][METRICS_TYPE][metric_name] = metric_data
-        end
+        dataset['servers'][hostkey][METRICS_TYPE][metric_name] = metric_data
       end
     end
 

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -99,7 +99,7 @@ def individually_retrieve_additional_metrics(host, port, metrics)
 
   metrics_array = []
   metrics.each do |metric|
-    endpoint = "#{host_url}/metrics/v1/mbeans/#{metric['url']}"
+    endpoint = URI.escape("#{host_url}/metrics/v1/mbeans/#{metric['url']}")
     metrics_array <<  { 'name' => metric['name'],
                         'data' => get_endpoint(endpoint) }
   end

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -107,6 +107,16 @@ def individually_retrieve_additional_metrics(host, port, metrics)
   return metrics_array
 end
 
+def retrieve_additional_metrics(host,port,metrics,pe_version)
+  if Gem::Version.new(pe_version) < Gem::Version.new('2016.2.0') then
+    metrics_array = individually_retrieve_additional_metrics(host, port, metrics)
+  else
+    metrics_array = bulk_retrieve_additional_metrics(host, port, metrics)
+  end
+
+  return metrics_array
+end
+
 filename = Time.now.utc.strftime('%Y%m%dT%H%M%SZ') + '.json'
 
 HOSTS.each do |host|
@@ -121,11 +131,8 @@ HOSTS.each do |host|
     dataset['servers'][hostkey] = {METRICS_TYPE => status_output}
 
     unless METRICS.empty? then
-      if Gem::Version.new(PE_VERSION) < Gem::Version.new('2016.2.0') then
-        metrics_array = individually_retrieve_additional_metrics(host, PORT, METRICS)
-      else
-        metrics_array = bulk_retrieve_additional_metrics(host, PORT, METRICS)
-      end
+      metrics_array = retrieve_additional_metrics(host, PORT, METRICS, PE_VERSION)
+
       metrics_array.each do |metric_hash|
         metric_name = metric_hash['name']
         metric_data = metric_hash['data']

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -64,6 +64,13 @@ rescue Exception => e
     data = {}
 end
 
+def get_status_endpoint(host, port)
+  host_url = "https://#{host}:#{port}"
+
+  status_endpoint = "#{host_url}/status/v1/services?level=debug"
+  status_output   = get_endpoint(status_endpoint)
+end
+
 filename = Time.now.utc.strftime('%Y%m%dT%H%M%SZ') + '.json'
 
 HOSTS.each do |host|
@@ -74,8 +81,7 @@ HOSTS.each do |host|
 
     host_url = "https://#{host}:#{PORT}"
 
-    status_endpoint = "#{host_url}/status/v1/services?level=debug"
-    status_output   = get_endpoint(status_endpoint)
+    status_output   = get_status_endpoint(host, PORT)
     dataset['servers'][hostkey] = {METRICS_TYPE => status_output}
 
     post_data = []

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -33,11 +33,18 @@ PE_VERSION = config['pe_version']
 
 $error_array = []
 
-def get_endpoint(url)
+def setup_connection(url)
   uri  = URI.parse(url)
   http = Net::HTTP.new(uri.host, uri.port)
   http.use_ssl = true
   http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+  return http,uri
+end
+
+def get_endpoint(url)
+  http,uri = setup_connection(url)
+
   data = JSON.parse(http.get(uri.request_uri).body)
 rescue Exception => e
     $error_array << "#{e}"
@@ -45,10 +52,7 @@ rescue Exception => e
 end
 
 def post_endpoint(url,post_data)
-  uri  = URI.parse(url)
-  http = Net::HTTP.new(uri.host, uri.port)
-  http.use_ssl = true
-  http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+  http,uri = setup_connection(url)
 
   request = Net::HTTP::Post.new(uri.request_uri)
   request.content_type = 'application/json'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "npwalker/pe_metric_curl_cron_jobs",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "author": "npwalker",
   "summary": "A Puppet module for gathering metrics from PE components",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR builds on top of #36.

This adds a metrics_port and no-ssl CLI option that will allow a user to gather metrics on PE < 2016.4 without using certificates by passing the http port for PuppetDB and --no-ssl.  PuppetServer does not have a http port.  

As it turns out PuppetDB places the metrics endpoint behind certificate auth in PDB < 4.2 so you cannot connect to it without certs in PE 2016.2 and below.  In PE 2016.4 and above it's fine to connect without certificates and SSL_NO_VERIFY as was just implemented in #34.

I could definitely improve this by passing around an http object instead of passing host,port, and ssl around everywhere but that can be fixed separately.  