### PR TITLE
Unify config

### DIFF
--- a/files/amq_metrics
+++ b/files/amq_metrics
@@ -7,31 +7,70 @@ require 'time'
 require 'optparse'
 require 'yaml'
 
-options = {}
-OptionParser.new do |opts|
-  opts.banner = "Usage: amq_metrics [options]"
+#===========================================================================#
+# BUILD CONFIGURATION OPTIONS                                               #
+#===========================================================================#
 
-  opts.on('-p', '--[no-]print', 'Print to stdout') { |p| options[:print] = p }
-  opts.on('-m [TYPE]', '--metrics_type [TYPE]', 'Type of metric to collect') { |v| options[:metrics_type] = v }
-  opts.on('-o [DIR]', '--output-dir [DIR]', 'Directory to save output to') { |o| options[:output_dir] = o }
+settings = { }
+config = { }
+from_cli = { }
+from_file = { }
+
+OptionParser.new do |parser|
+  parser.banner = "Usage: tk_metrics [options]"
+
+  save_ident = lambda { |name,arg| from_cli[name] = arg }
+  save_list  = lambda { |name,arg| from_cli[name] = arg.split(',') }
+
+  opt_bool  = lambda { |arg| "--[no-]#{arg}" }
+  opt_value = lambda { |arg| "--#{arg} ARG" }
+
+  option = lambda do |name,desc,fopt,fsave,default=nil|
+    settings[name] = { default: default }
+    parser.on(fopt.call(name.to_s), desc) { |arg| fsave.call(name, arg) }
+  end
+
+  # Each possible configuration option is defined here
+  option.call(:config, 'Path to configuration file', opt_value, save_ident, false)
+  option.call(:"output-dir", 'Directory to save output to', opt_value, save_ident, false)
+  option.call(:hosts, 'Hosts to collect metrics from (comma-separated)', opt_value, save_list, ['localhost'])
+  option.call(:"additional-metrics", 'Additional metrics to collect (comma-separated)', opt_value, save_list, [])
+  option.call(:"metrics-port", 'The port the metrics service runs on', opt_value, save_ident)
+  option.call(:clientcert, 'Not used', opt_value, save_ident)
+  option.call(:"pe-version", 'The version of PE in use', opt_value, save_ident)
+  option.call(:print, 'Print to stdout', opt_bool, save_ident, true)
+  option.call(:ssl, 'Whether or not to use SSL when gather metrics', opt_bool, save_ident, true)
+  option.call(:"metrics-type", 'Type of metric to collect', opt_value, save_ident)
+
+  # Kinda pointless to include descriptions unless there's a help flag
+  parser.on("-h", "--help", "Prints this help") { puts parser; exit }
+
 end.parse!
 
-if options[:metrics_type].nil? then
-  STDERR.puts '--metrics_type (-m) is a required argument'
-  exit 1
+# If a configuration file has been specified, read additional configuration
+# from it.
+if from_cli[:config]
+  begin
+    from_file = YAML.load_file(from_cli[:config])
+  rescue Exception => e
+    STDERR.puts "ERROR: unable to read configuration from #{config[:config]}: #{e}"
+    exit 1
+  end
 end
 
-METRICS_TYPE = options[:metrics_type]
-config = YAML.load_file(File.join(File.dirname(File.expand_path(__FILE__)),"#{METRICS_TYPE}_config.yaml"))
+# For the options which MAY be read from a config file, retrieve those values
+# if they have not been specified during invocation. Values specified on the
+# command line are given precedence.
+settings.each do |opt,attrs|
+  possibilities = [from_cli[opt], from_file[opt.to_s], attrs[:default]]
+  if (config[opt] = possibilities.find {|p| !p.nil? }).nil?
+    raise("ERROR: Missing configuration option \"#{opt}\"")
+  end
+end
 
-OUTPUT_DIR = options[:output_dir]
-HOSTS      = config['hosts']
-PORT       = config['metrics_port']
-METRICS    = config['additional_metrics']
-CLIENTCERT = config['clientcert']
-PE_VERSION = config['pe_version']
-
-POST_DATA = METRICS.to_json
+#===========================================================================#
+# MAIN SCRIPT LOGIC                                                         #
+#===========================================================================#
 
 def recurse_merge!(a,b)
   a.merge!(b) do |_,aa,bb|
@@ -70,49 +109,50 @@ end
 
 filename = Time.now.utc.strftime('%Y%m%dT%H%M%SZ') + '.json'
 
-HOSTS.each do |host|
+config[:hosts].each do |host|
   begin
     timestamp = Time.now
     dataset = {'timestamp' => timestamp.utc.iso8601, 'servers' => {}}
     hostkey = host.gsub('.', '-')
-    dataset['servers'][hostkey] = {METRICS_TYPE => {}}
+    dataset['servers'][hostkey] = {config[:"metrics-type"] => {}}
 
-    host_url = "https://#{host}:#{PORT}/api/jolokia"
-    response = get_endpoint(host_url, POST_DATA)
+    host_url = "http://#{host}:#{config[:"metrics-port"]}/api/jolokia"
+    response = get_endpoint(host_url, config[:"additional-metrics"].to_json)
 
     JSON.parse(response.body).each do |element|
       case element['value']
       when Hash
         element['value'].each do |mbean,attributes|
           metrics = treeify(mbean, attributes)
-          recurse_merge!(dataset['servers'][hostkey][METRICS_TYPE], metrics)
+          recurse_merge!(dataset['servers'][hostkey][config[:"metrics-type"]], metrics)
         end
       else
         req = element['request']
         metrics = treeify(req['mbean'], { req['attribute'] => req['value'] })
-        recurse_merge!(dataset['servers'][hostkey][METRICS_TYPE], metrics)
+        recurse_merge!(dataset['servers'][hostkey][config[:"metrics-type"]], metrics)
       end
     end
 
-    dataset['servers'][hostkey][METRICS_TYPE]['error'] = $error_array
-    dataset['servers'][hostkey][METRICS_TYPE]['error_count'] = $error_array.count
-    dataset['servers'][hostkey][METRICS_TYPE]['api-query-start'] = timestamp.utc.iso8601
-    dataset['servers'][hostkey][METRICS_TYPE]['api-query-duration'] = Time.now - timestamp
+    dataset['servers'][hostkey][config[:"metrics-type"]]['error'] = $error_array
+    dataset['servers'][hostkey][config[:"metrics-type"]]['error_count'] = $error_array.count
+    dataset['servers'][hostkey][config[:"metrics-type"]]['api-query-start'] = timestamp.utc.iso8601
+    dataset['servers'][hostkey][config[:"metrics-type"]]['api-query-duration'] = Time.now - timestamp
 
     json_dataset = JSON.pretty_generate(dataset)
 
-    unless OUTPUT_DIR.nil? then
-      Dir.chdir(OUTPUT_DIR) do
+    if config[:"output-dir"] then
+      Dir.chdir(config[:"output-dir"]) do
         Dir.mkdir(host) unless File.exist?(host)
         File.open(File.join(host, filename), 'w') do |file|
           file.write(json_dataset)
         end
       end
     end
-    if options[:print] != false then
+    if config[:print] then
       STDOUT.write(json_dataset)
     end
   rescue Exception => e
     STDERR.puts "Error getting metrics for #{host}: #{e}"
+    STDERR.puts e.backtrace
   end
 end

--- a/files/amq_metrics
+++ b/files/amq_metrics
@@ -31,10 +31,10 @@ OptionParser.new do |parser|
   end
 
   # Each possible configuration option is defined here
-  option.call(:config, 'Path to configuration file', opt_value, save_ident, false)
-  option.call(:"output-dir", 'Directory to save output to', opt_value, save_ident, false)
+  option.call(:config, 'Path to configuration file', opt_value, save_ident, :undef)
+  option.call(:"output-dir", 'Directory to save output to', opt_value, save_ident, :undef)
   option.call(:hosts, 'Hosts to collect metrics from (comma-separated)', opt_value, save_list, ['localhost'])
-  option.call(:"additional-metrics", 'Additional metrics to collect (comma-separated)', opt_value, save_list, [])
+  option.call(:"additional-metrics", 'Additional metrics to collect (comma-separated)', opt_value, save_list)
   option.call(:"metrics-port", 'The port the metrics service runs on', opt_value, save_ident)
   option.call(:clientcert, 'Not used', opt_value, save_ident)
   option.call(:"pe-version", 'The version of PE in use', opt_value, save_ident)
@@ -49,7 +49,7 @@ end.parse!
 
 # If a configuration file has been specified, read additional configuration
 # from it.
-if from_cli[:config]
+unless :undef == from_cli[:config]
   begin
     from_file = YAML.load_file(from_cli[:config])
   rescue Exception => e
@@ -140,7 +140,7 @@ config[:hosts].each do |host|
 
     json_dataset = JSON.pretty_generate(dataset)
 
-    if config[:"output-dir"] then
+    unless :undef == config[:"output-dir"]
       Dir.chdir(config[:"output-dir"]) do
         Dir.mkdir(host) unless File.exist?(host)
         File.open(File.join(host, filename), 'w') do |file|
@@ -148,7 +148,7 @@ config[:hosts].each do |host|
         end
       end
     end
-    if config[:print] then
+    if config[:print]
       STDOUT.write(json_dataset)
     end
   rescue Exception => e

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -7,44 +7,71 @@ require 'time'
 require 'optparse'
 require 'yaml'
 
-options = {}
+#===========================================================================#
+# BUILD CONFIGURATION OPTIONS                                               #
+#===========================================================================#
+
+# Define the list of mandatory options that must be specified on the CLI
+REQUIRED_FLAGS = {
+  metrics_type: { type: :string },
+}
+
+# Define the list of options that will be read from the config file, and which
+# may optionally be specified on the CLI.
+SETTINGS = {
+  output_dir:   { type: :string, default: false }, # false = disabled
+  hosts:        { type: :list },
+  metrics:      { type: :list },
+  metrics_port: { type: :string },
+  clientcert:   { type: :string },
+  pe_version:   { type: :string },
+  print:        { type: :boolean, default: true },
+  ssl:          { type: :boolean, default: true },
+}
+
+config = { }
+
 OptionParser.new do |opts|
   opts.banner = "Usage: tk_metrics [options]"
 
-  opts.on('-p', '--[no-]print', 'Print to stdout') { |p| options[:print] = p }
-  opts.on('-m [TYPE]', '--metrics_type [TYPE]', 'Type of metric to collect') { |v| options[:metrics_type] = v }
-  opts.on('-o [DIR]', '--output-dir [DIR]', 'Directory to save output to') { |o| options[:output_dir] = o }
-  opts.on('--metrics_port [PORT]', 'The port the metrics service runs on') { |port| options[:metrics_port] = port }
-  opts.on('--[no-]ssl', 'Whether or not to use SSL when gather metrics') { |ssl| options[:ssl] = ssl }
+  # Gather options
+  REQUIRED_FLAGS.merge(SETTINGS).each do |opt,attrs|
+    case attrs[:type]
+    when :string, nil
+      opts.on("--#{opt} ARG", '(no description)')  { |arg| config[opt] = arg }
+    when :boolean
+      opts.on("--[no-]#{opt}", '(no description)') { |arg| config[opt] = arg }
+    when :list
+      opts.on("--#{opt} ARG", '(no description)')  { |arg| config[opt] = arg.split(',') }
+    end
+  end
+
 end.parse!
 
-if options[:metrics_type].nil? then
-  STDERR.puts '--metrics_type (-m) is a required argument'
+REQUIRED_FLAGS.each_key do |opt|
+  !config[opt].nil? || raise("ERROR: Missing configuration option \"#{opt}\"")
+end
+
+begin
+  file = File.join(File.dirname(File.expand_path(__FILE__)),"#{config[:metrics_type]}_config.yaml")
+  file_config = YAML.load_file(file)
+rescue Exception => e
+  STDERR.puts "ERROR: unable to read configuration file from #{file}: #{e}"
   exit 1
 end
 
-METRICS_TYPE = options[:metrics_type]
-config = YAML.load_file(File.join(File.dirname(File.expand_path(__FILE__)),"#{METRICS_TYPE}_config.yaml"))
-
-def coalesce ( opt1, opt2, default=nil )
-  if opt1.nil? then
-    if opt2.nil? then
-      default
-    else
-      opt2
-    end
-  else
-    opt1
-  end
+# For the options which MAY be read from a config file, retrieve those values
+# if they have not been specified during invocation. Values specified on the
+# command line are given precedence.
+SETTINGS.each do |opt,attrs|
+  possibilities = [config[opt], file_config[opt], attrs[:default]]
+  config[opt] = possibilities.find {|p| !p.nil? }
+  raise("ERROR: Missing configuration option \"#{opt}\"") if config[opt].nil?
 end
 
-OUTPUT_DIR = options[:output_dir]
-HOSTS      = config['hosts']
-PORT       = coalesce(options[:metrics_port], config['metrics_port'])
-METRICS    = config['additional_metrics']
-CLIENTCERT = config['clientcert']
-PE_VERSION = config['pe_version']
-SSL        = coalesce(options[:ssl], config['ssl'], true)
+#===========================================================================#
+# MAIN SCRIPT LOGIC                                                         #
+#===========================================================================#
 
 $error_array = []
 
@@ -146,42 +173,42 @@ end
 
 filename = Time.now.utc.strftime('%Y%m%dT%H%M%SZ') + '.json'
 
-HOSTS.each do |host|
+config[:hosts].each do |host|
   begin
     timestamp = Time.now
     dataset = {'timestamp' => timestamp.utc.iso8601, 'servers' => {}}
     hostkey = host.gsub('.', '-')
 
-    status_output   = get_status_endpoint(host, PORT, SSL)
-    dataset['servers'][hostkey] = {METRICS_TYPE => status_output}
+    status_output   = get_status_endpoint(host, config[:metrics_port], config[:ssl])
+    dataset['servers'][hostkey] = {config[:metrics_type] => status_output}
 
-    unless METRICS.empty? then
-      metrics_array = retrieve_additional_metrics(host, PORT, METRICS, PE_VERSION, SSL)
+    unless config[:metrics].empty? then
+      metrics_array = retrieve_additional_metrics(host, config[:metrics_port], config[:metrics], config[:pe_version], config[:ssl])
 
       metrics_array.each do |metric_hash|
         metric_name = metric_hash['name']
         metric_data = metric_hash['data']
 
-        dataset['servers'][hostkey][METRICS_TYPE][metric_name] = metric_data
+        dataset['servers'][hostkey][config[:metrics_type]][metric_name] = metric_data
       end
     end
 
-    dataset['servers'][hostkey][METRICS_TYPE]['error'] = $error_array
-    dataset['servers'][hostkey][METRICS_TYPE]['error_count'] = $error_array.count
-    dataset['servers'][hostkey][METRICS_TYPE]['api-query-start'] = timestamp.utc.iso8601
-    dataset['servers'][hostkey][METRICS_TYPE]['api-query-duration'] = Time.now - timestamp
+    dataset['servers'][hostkey][config[:metrics_type]]['error'] = $error_array
+    dataset['servers'][hostkey][config[:metrics_type]]['error_count'] = $error_array.count
+    dataset['servers'][hostkey][config[:metrics_type]]['api-query-start'] = timestamp.utc.iso8601
+    dataset['servers'][hostkey][config[:metrics_type]]['api-query-duration'] = Time.now - timestamp
 
     json_dataset = JSON.pretty_generate(dataset)
 
-    unless OUTPUT_DIR.nil? then
-      Dir.chdir(OUTPUT_DIR) do
+    unless config[:output_dir] == false then
+      Dir.chdir(config[:output_dir]) do
         Dir.mkdir(host) unless File.exist?(host)
         File.open(File.join(host, filename), 'w') do |file|
           file.write(json_dataset)
         end
       end
     end
-    if options[:print] != false then
+    if config[:print] != false then
       STDOUT.write(json_dataset)
     end
   end

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -13,20 +13,20 @@ require 'yaml'
 
 # Define the list of mandatory options that must be specified on the CLI
 REQUIRED_FLAGS = {
-  metrics_type: { type: :string },
+  :"metrics-type" => { type: :string },
 }
 
 # Define the list of options that will be read from the config file, and which
 # may optionally be specified on the CLI.
 SETTINGS = {
-  output_dir:   { type: :string, default: false }, # false = disabled
-  hosts:        { type: :list },
-  metrics:      { type: :list },
-  metrics_port: { type: :string },
-  clientcert:   { type: :string },
-  pe_version:   { type: :string },
-  print:        { type: :boolean, default: true },
-  ssl:          { type: :boolean, default: true },
+  :"output-dir"   => { type: :string, default: false }, # false = disabled
+  :hosts          => { type: :list },
+  :metrics        => { type: :list },
+  :"metrics-port" => { type: :string },
+  :clientcert     => { type: :string },
+  :"pe-version"   => { type: :string },
+  :print          => { type: :boolean, default: true },
+  :ssl            => { type: :boolean, default: true },
 }
 
 config = { }
@@ -53,7 +53,7 @@ REQUIRED_FLAGS.each_key do |opt|
 end
 
 begin
-  file = File.join(File.dirname(File.expand_path(__FILE__)),"#{config[:metrics_type]}_config.yaml")
+  file = File.join(File.dirname(File.expand_path(__FILE__)),"#{config[:"metrics-type"]}_config.yaml")
   file_config = YAML.load_file(file)
 rescue Exception => e
   STDERR.puts "ERROR: unable to read configuration file from #{file}: #{e}"
@@ -179,29 +179,29 @@ config[:hosts].each do |host|
     dataset = {'timestamp' => timestamp.utc.iso8601, 'servers' => {}}
     hostkey = host.gsub('.', '-')
 
-    status_output   = get_status_endpoint(host, config[:metrics_port], config[:ssl])
-    dataset['servers'][hostkey] = {config[:metrics_type] => status_output}
+    status_output   = get_status_endpoint(host, config[:"metrics-port"], config[:ssl])
+    dataset['servers'][hostkey] = {config[:"metrics-type"] => status_output}
 
     unless config[:metrics].empty? then
-      metrics_array = retrieve_additional_metrics(host, config[:metrics_port], config[:metrics], config[:pe_version], config[:ssl])
+      metrics_array = retrieve_additional_metrics(host, config[:"metrics-port"], config[:metrics], config[:"pe-version"], config[:ssl])
 
       metrics_array.each do |metric_hash|
         metric_name = metric_hash['name']
         metric_data = metric_hash['data']
 
-        dataset['servers'][hostkey][config[:metrics_type]][metric_name] = metric_data
+        dataset['servers'][hostkey][config[:"metrics-type"]][metric_name] = metric_data
       end
     end
 
-    dataset['servers'][hostkey][config[:metrics_type]]['error'] = $error_array
-    dataset['servers'][hostkey][config[:metrics_type]]['error_count'] = $error_array.count
-    dataset['servers'][hostkey][config[:metrics_type]]['api-query-start'] = timestamp.utc.iso8601
-    dataset['servers'][hostkey][config[:metrics_type]]['api-query-duration'] = Time.now - timestamp
+    dataset['servers'][hostkey][config[:"metrics-type"]]['error'] = $error_array
+    dataset['servers'][hostkey][config[:"metrics-type"]]['error_count'] = $error_array.count
+    dataset['servers'][hostkey][config[:"metrics-type"]]['api-query-start'] = timestamp.utc.iso8601
+    dataset['servers'][hostkey][config[:"metrics-type"]]['api-query-duration'] = Time.now - timestamp
 
     json_dataset = JSON.pretty_generate(dataset)
 
-    unless config[:output_dir] == false then
-      Dir.chdir(config[:output_dir]) do
+    unless config[:"output-dir"] == false then
+      Dir.chdir(config[:"output-dir"]) do
         Dir.mkdir(host) unless File.exist?(host)
         File.open(File.join(host, filename), 'w') do |file|
           file.write(json_dataset)

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -47,27 +47,14 @@ OptionParser.new do |parser|
 
 end.parse!
 
-# This is to support legacy from the time when passing --metrics-type was what
-# determined the filename of the config file, rather than the --config option.
-metrics_type_file = if from_cli[:"metrics-type"]
-  scriptdir = File.dirname(File.expand_path(__FILE__))
-  legacyfile = "#{from_cli[:"metrics-type"]}_config.yaml"
-  File.join(scriptdir, legacyfile)
-end
-
 # If a configuration file has been specified, read additional configuration
-# from it. Some complexity exists due to support for metrics-type filename.
-config[:config] = from_cli[:config] || metrics_type_file
-if config[:config]
+# from it.
+if from_cli[:config]
   begin
-    from_file = YAML.load_file(config[:config])
+    from_file = YAML.load_file(from_cli[:config])
   rescue Exception => e
-    if from_cli[:config] # means we're not using a metrics-type filename
-      STDERR.puts "ERROR: unable to read configuration from #{config[:config]}: #{e}"
-      exit 1
-    else
-      STDERR.puts "WARN: unable to read configuration from #{config[:config]}: #{e}"
-    end
+    STDERR.puts "ERROR: unable to read configuration from #{config[:config]}: #{e}"
+    exit 1
   end
 end
 
@@ -76,8 +63,9 @@ end
 # command line are given precedence.
 settings.each do |opt,attrs|
   possibilities = [from_cli[opt], from_file[opt.to_s], attrs[:default]]
-  config[opt] = possibilities.find {|p| !p.nil? }
-  raise("ERROR: Missing configuration option \"#{opt}\"") if config[opt].nil?
+  if (config[opt] = possibilities.find {|p| !p.nil? }).nil?
+    raise("ERROR: Missing configuration option \"#{opt}\"")
+  end
 end
 
 #===========================================================================#

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -31,10 +31,10 @@ OptionParser.new do |parser|
   end
 
   # Each possible configuration option is defined here
-  option.call(:config, 'Path to configuration file', opt_value, save_ident, false)
-  option.call(:"output-dir", 'Directory to save output to', opt_value, save_ident, false)
+  option.call(:config, 'Path to configuration file', opt_value, save_ident, :undef)
+  option.call(:"output-dir", 'Directory to save output to', opt_value, save_ident, :undef)
   option.call(:hosts, 'Hosts to collect metrics from (comma-separated)', opt_value, save_list, ['localhost'])
-  option.call(:"additional-metrics", 'Additional metrics to collect (comma-separated)', opt_value, save_list, [])
+  option.call(:"additional-metrics", 'Additional metrics to collect (comma-separated)', opt_value, save_list, :undef)
   option.call(:"metrics-port", 'The port the metrics service runs on', opt_value, save_ident)
   option.call(:clientcert, 'Not used', opt_value, save_ident)
   option.call(:"pe-version", 'The version of PE in use', opt_value, save_ident)
@@ -49,7 +49,7 @@ end.parse!
 
 # If a configuration file has been specified, read additional configuration
 # from it.
-if from_cli[:config]
+unless :undef == from_cli[:config]
   begin
     from_file = YAML.load_file(from_cli[:config])
   rescue Exception => e
@@ -181,7 +181,7 @@ config[:hosts].each do |host|
     status_output   = get_status_endpoint(host, config[:"metrics-port"], config[:ssl])
     dataset['servers'][hostkey] = {config[:"metrics-type"] => status_output}
 
-    unless config[:"additional-metrics"].empty? then
+    unless :undef == config[:"additional-metrics"]
       metrics_array = retrieve_additional_metrics(host, config[:"metrics-port"], config[:"additional-metrics"], config[:"pe-version"], config[:ssl])
 
       metrics_array.each do |metric_hash|
@@ -199,7 +199,7 @@ config[:hosts].each do |host|
 
     json_dataset = JSON.pretty_generate(dataset)
 
-    unless config[:"output-dir"] == false then
+    unless :undef == config[:"output-dir"]
       Dir.chdir(config[:"output-dir"]) do
         Dir.mkdir(host) unless File.exist?(host)
         File.open(File.join(host, filename), 'w') do |file|
@@ -207,7 +207,7 @@ config[:hosts].each do |host|
         end
       end
     end
-    if config[:print] != false then
+    if config[:print]
       STDOUT.write(json_dataset)
     end
   end

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -17,28 +17,31 @@ config = { }
 OptionParser.new do |parser|
   parser.banner = "Usage: tk_metrics [options]"
 
-  ident = lambda { |name,arg| config[name] = arg }
-  list = lambda { |name,arg| config[name] = arg.split(',') }
+  save_ident = lambda { |name,arg| config[name] = arg }
+  save_list  = lambda { |name,arg| config[name] = arg.split(',') }
 
-  option = lambda do |name,opt,desc,save,default=nil|
+  opt_bool  = lambda { |arg| "--[no-]#{arg}" }
+  opt_value = lambda { |arg| "--#{arg} ARG" }
+
+  option = lambda do |name,desc,fopt,fsave,default=nil|
     settings[name] = { default: default }
-    parser.on(opt, desc) do |arg|
-      save.call(name, arg)
+    parser.on(fopt.call(name.to_s), desc) do |arg|
+      fsave.call(name, arg)
     end
   end
 
   # Each possible configuration option is defined here
-  option.call(:"output-dir", '--output-dir ARG', 'Directory to save output to', ident, false)
-  option.call(:hosts, '--hosts ARG', 'Hosts to collect metrics from (comma-separated)', list, ['localhost'])
-  option.call(:"additional-metrics", '--additional-metrics ARG', 'Additional metrics to collect (comma-separated)', list, [])
-  option.call(:"metrics-port", '--metrics-port ARG', 'The port the metrics service runs on', ident)
-  option.call(:clientcert, '--clientcert ARG', 'Not used', ident)
-  option.call(:"pe-version", '--pe-version ARG', 'The version of PE in use', ident)
-  option.call(:print, '--[no-]print ARG', 'Print to stdout', ident, true)
-  option.call(:ssl, '--[no-]ssl ARG', 'Whether or not to use SSL when gather metrics', ident, true)
+  option.call(:"output-dir", 'Directory to save output to', opt_value, save_ident, false)
+  option.call(:hosts, 'Hosts to collect metrics from (comma-separated)', opt_value, save_list, ['localhost'])
+  option.call(:"additional-metrics", 'Additional metrics to collect (comma-separated)', opt_value, save_list, [])
+  option.call(:"metrics-port", 'The port the metrics service runs on', opt_value, save_ident)
+  option.call(:clientcert, 'Not used', opt_value, save_ident)
+  option.call(:"pe-version", 'The version of PE in use', opt_value, save_ident)
+  option.call(:print, 'Print to stdout', opt_bool, save_ident, true)
+  option.call(:ssl, 'Whether or not to use SSL when gather metrics', opt_bool, save_ident, true)
 
   # This one is special because it's required
-  option.call(:"metrics-type", '--metrics-type ARG', 'Type of metric to collect', ident)
+  option.call(:"metrics-type", 'Type of metric to collect', opt_value, save_ident)
 
   # Kinda pointless to include descriptions unless there's a help flag
   parser.on("-h", "--help", "Prints this help") { puts parser; exit }

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -11,46 +11,41 @@ require 'yaml'
 # BUILD CONFIGURATION OPTIONS                                               #
 #===========================================================================#
 
-# Define the list of mandatory options that must be specified on the CLI
-REQUIRED_FLAGS = {
-  :"metrics-type" => { type: :string },
-}
-
-# Define the list of options that will be read from the config file, and which
-# may optionally be specified on the CLI.
-SETTINGS = {
-  :"output-dir"   => { type: :string, default: false }, # false = disabled
-  :hosts          => { type: :list },
-  :metrics        => { type: :list },
-  :"metrics-port" => { type: :string },
-  :clientcert     => { type: :string },
-  :"pe-version"   => { type: :string },
-  :print          => { type: :boolean, default: true },
-  :ssl            => { type: :boolean, default: true },
-}
-
+settings = { }
 config = { }
 
-OptionParser.new do |opts|
-  opts.banner = "Usage: tk_metrics [options]"
+OptionParser.new do |parser|
+  parser.banner = "Usage: tk_metrics [options]"
 
-  # Gather options
-  REQUIRED_FLAGS.merge(SETTINGS).each do |opt,attrs|
-    case attrs[:type]
-    when :string, nil
-      opts.on("--#{opt} ARG", '(no description)')  { |arg| config[opt] = arg }
-    when :boolean
-      opts.on("--[no-]#{opt}", '(no description)') { |arg| config[opt] = arg }
-    when :list
-      opts.on("--#{opt} ARG", '(no description)')  { |arg| config[opt] = arg.split(',') }
+  ident = lambda { |name,arg| config[name] = arg }
+  list = lambda { |name,arg| config[name] = arg.split(',') }
+
+  option = lambda do |name,opt,desc,save,default=nil|
+    settings[name] = { default: default }
+    parser.on(opt, desc) do |arg|
+      save.call(name, arg)
     end
   end
 
+  # Each possible configuration option is defined here
+  option.call(:"output-dir", '--output-dir ARG', 'Directory to save output to', ident, false)
+  option.call(:hosts, '--hosts ARG', 'Hosts to collect metrics from (comma-separated)', list, ['localhost'])
+  option.call(:"additional-metrics", '--additional-metrics ARG', 'Additional metrics to collect (comma-separated)', list, [])
+  option.call(:"metrics-port", '--metrics-port ARG', 'The port the metrics service runs on', ident)
+  option.call(:clientcert, '--clientcert ARG', 'Not used', ident)
+  option.call(:"pe-version", '--pe-version ARG', 'The version of PE in use', ident)
+  option.call(:print, '--[no-]print ARG', 'Print to stdout', ident, true)
+  option.call(:ssl, '--[no-]ssl ARG', 'Whether or not to use SSL when gather metrics', ident, true)
+
+  # This one is special because it's required
+  option.call(:"metrics-type", '--metrics-type ARG', 'Type of metric to collect', ident)
+
+  # Kinda pointless to include descriptions unless there's a help flag
+  parser.on("-h", "--help", "Prints this help") { puts parser; exit }
+
 end.parse!
 
-REQUIRED_FLAGS.each_key do |opt|
-  !config[opt].nil? || raise("ERROR: Missing configuration option \"#{opt}\"")
-end
+raise('ERROR: Missing configuration option "metrics-type"') if config[:"metrics-type"].nil?
 
 begin
   file = File.join(File.dirname(File.expand_path(__FILE__)),"#{config[:"metrics-type"]}_config.yaml")
@@ -63,7 +58,7 @@ end
 # For the options which MAY be read from a config file, retrieve those values
 # if they have not been specified during invocation. Values specified on the
 # command line are given precedence.
-SETTINGS.each do |opt,attrs|
+settings.each do |opt,attrs|
   possibilities = [config[opt], file_config[opt], attrs[:default]]
   config[opt] = possibilities.find {|p| !p.nil? }
   raise("ERROR: Missing configuration option \"#{opt}\"") if config[opt].nil?
@@ -182,8 +177,8 @@ config[:hosts].each do |host|
     status_output   = get_status_endpoint(host, config[:"metrics-port"], config[:ssl])
     dataset['servers'][hostkey] = {config[:"metrics-type"] => status_output}
 
-    unless config[:metrics].empty? then
-      metrics_array = retrieve_additional_metrics(host, config[:"metrics-port"], config[:metrics], config[:"pe-version"], config[:ssl])
+    unless config[:"additional-metrics"].empty? then
+      metrics_array = retrieve_additional_metrics(host, config[:"metrics-port"], config[:"additional-metrics"], config[:"pe-version"], config[:ssl])
 
       metrics_array.each do |metric_hash|
         metric_name = metric_hash['name']

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -13,24 +13,25 @@ require 'yaml'
 
 settings = { }
 config = { }
+from_cli = { }
+from_file = { }
 
 OptionParser.new do |parser|
   parser.banner = "Usage: tk_metrics [options]"
 
-  save_ident = lambda { |name,arg| config[name] = arg }
-  save_list  = lambda { |name,arg| config[name] = arg.split(',') }
+  save_ident = lambda { |name,arg| from_cli[name] = arg }
+  save_list  = lambda { |name,arg| from_cli[name] = arg.split(',') }
 
   opt_bool  = lambda { |arg| "--[no-]#{arg}" }
   opt_value = lambda { |arg| "--#{arg} ARG" }
 
   option = lambda do |name,desc,fopt,fsave,default=nil|
     settings[name] = { default: default }
-    parser.on(fopt.call(name.to_s), desc) do |arg|
-      fsave.call(name, arg)
-    end
+    parser.on(fopt.call(name.to_s), desc) { |arg| fsave.call(name, arg) }
   end
 
   # Each possible configuration option is defined here
+  option.call(:config, 'Path to configuration file', opt_value, save_ident, false)
   option.call(:"output-dir", 'Directory to save output to', opt_value, save_ident, false)
   option.call(:hosts, 'Hosts to collect metrics from (comma-separated)', opt_value, save_list, ['localhost'])
   option.call(:"additional-metrics", 'Additional metrics to collect (comma-separated)', opt_value, save_list, [])
@@ -39,8 +40,6 @@ OptionParser.new do |parser|
   option.call(:"pe-version", 'The version of PE in use', opt_value, save_ident)
   option.call(:print, 'Print to stdout', opt_bool, save_ident, true)
   option.call(:ssl, 'Whether or not to use SSL when gather metrics', opt_bool, save_ident, true)
-
-  # This one is special because it's required
   option.call(:"metrics-type", 'Type of metric to collect', opt_value, save_ident)
 
   # Kinda pointless to include descriptions unless there's a help flag
@@ -48,21 +47,35 @@ OptionParser.new do |parser|
 
 end.parse!
 
-raise('ERROR: Missing configuration option "metrics-type"') if config[:"metrics-type"].nil?
+# This is to support legacy from the time when passing --metrics-type was what
+# determined the filename of the config file, rather than the --config option.
+metrics_type_file = if from_cli[:"metrics-type"]
+  scriptdir = File.dirname(File.expand_path(__FILE__))
+  legacyfile = "#{from_cli[:"metrics-type"]}_config.yaml"
+  File.join(scriptdir, legacyfile)
+end
 
-begin
-  file = File.join(File.dirname(File.expand_path(__FILE__)),"#{config[:"metrics-type"]}_config.yaml")
-  file_config = YAML.load_file(file)
-rescue Exception => e
-  STDERR.puts "ERROR: unable to read configuration file from #{file}: #{e}"
-  exit 1
+# If a configuration file has been specified, read additional configuration
+# from it. Some complexity exists due to support for metrics-type filename.
+config[:config] = from_cli[:config] || metrics_type_file
+if config[:config]
+  begin
+    from_file = YAML.load_file(config[:config])
+  rescue Exception => e
+    if from_cli[:config] # means we're not using a metrics-type filename
+      STDERR.puts "ERROR: unable to read configuration from #{config[:config]}: #{e}"
+      exit 1
+    else
+      STDERR.puts "WARN: unable to read configuration from #{config[:config]}: #{e}"
+    end
+  end
 end
 
 # For the options which MAY be read from a config file, retrieve those values
 # if they have not been specified during invocation. Values specified on the
 # command line are given precedence.
 settings.each do |opt,attrs|
-  possibilities = [config[opt], file_config[opt], attrs[:default]]
+  possibilities = [from_cli[opt], from_file[opt.to_s], attrs[:default]]
   config[opt] = possibilities.find {|p| !p.nil? }
   raise("ERROR: Missing configuration option \"#{opt}\"") if config[opt].nil?
 end

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -25,7 +25,7 @@ define pe_metric_curl_cron_jobs::pe_metric (
     'hosts'              => $hosts,
     'metrics-type'       => $metrics_type,
     'metrics-port'       => $metrics_port,
-    'metrics'            => $additional_metrics,
+    'additional-metrics' => $additional_metrics,
     'clientcert'         => $::clientcert,
     'pe-version'         => $facts['pe_server_version'],
     'ssl'                => $ssl,

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -23,11 +23,11 @@ define pe_metric_curl_cron_jobs::pe_metric (
 
   $config_hash = {
     'hosts'              => $hosts,
-    'metrics_type'       => $metrics_type,
-    'metrics_port'       => $metrics_port,
+    'metrics-type'       => $metrics_type,
+    'metrics-port'       => $metrics_port,
     'metrics'            => $additional_metrics,
     'clientcert'         => $::clientcert,
-    'pe_version'         => $facts['pe_server_version'],
+    'pe-version'         => $facts['pe_server_version'],
     'ssl'                => $ssl,
   }
 

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -25,7 +25,7 @@ define pe_metric_curl_cron_jobs::pe_metric (
     'hosts'              => $hosts,
     'metrics_type'       => $metrics_type,
     'metrics_port'       => $metrics_port,
-    'additional_metrics' => $additional_metrics,
+    'metrics'            => $additional_metrics,
     'clientcert'         => $::clientcert,
     'pe_version'         => $facts['pe_server_version'],
     'ssl'                => $ssl,

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -31,7 +31,9 @@ define pe_metric_curl_cron_jobs::pe_metric (
     'ssl'                => $ssl,
   }
 
-  file { "${scripts_dir}/${metrics_type}_config.yaml" :
+  $config_file = "${scripts_dir}/${metrics_type}_config.yaml"
+
+  file { $config_file:
     ensure  => $metric_ensure,
     mode    => '0644',
     content => $config_hash.pe_metric_curl_cron_jobs::to_yaml(),
@@ -41,7 +43,7 @@ define pe_metric_curl_cron_jobs::pe_metric (
 
   cron { "${metrics_type}_metrics_collection" :
     ensure  => $metric_ensure,
-    command => "${script_file_name} --metrics_type ${metrics_type} --output-dir ${metrics_output_dir} --no-print",
+    command => "${script_file_name} --config ${config_file} --output-dir ${metrics_output_dir} --no-print",
     user    => 'root',
     minute  => $cron_minute,
   }


### PR DESCRIPTION
Builds on #37.

This is effectively a cleanup of the way config options work. Any config option can now be read from a file, OR passed on the CLI. Valid config options must be specified as part of the SETTINGS array.