### PR TITLE
Default to no-ssl when PuppetDB on loopback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Z Release 4.4.1
+
+## Bug Fixes:
+ - PuppetDB metrics could not be gathered by default in PE < 2016.4.0
+   - [PR #39](https://github.com/npwalker/pe_metric_curl_cron_jobs/pull/39)
+
 # Minor Release 4.4.0
 
 ## Improvements

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -9,6 +9,7 @@ define pe_metric_curl_cron_jobs::pe_metric (
   Integer                   $retention_days = 90,
   String                    $metric_script_file = 'tk_metrics',
   Array[Hash]               $additional_metrics = [],
+  Boolean                   $ssl                = true,
 ) {
 
   $metrics_output_dir = "${output_dir}/${metrics_type}"
@@ -27,6 +28,7 @@ define pe_metric_curl_cron_jobs::pe_metric (
     'additional_metrics' => $additional_metrics,
     'clientcert'         => $::clientcert,
     'pe_version'         => $facts['pe_server_version'],
+    'ssl'                => $ssl,
   }
 
   file { "${scripts_dir}/${metrics_type}_config.yaml" :

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -146,10 +146,22 @@ class pe_metric_curl_cron_jobs::puppetdb (
     default  => $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics,
   }
 
+  $_ssl = $hosts ? {
+    [ '127.0.0.1' ] => false,
+    default         => true,
+  }
+
+  if $port == 8081 and $_ssl == false {
+    $_port = 8080
+  } else {
+    $_port = $port
+  }
+
   pe_metric_curl_cron_jobs::pe_metric { 'puppetdb' :
     metric_ensure => $metrics_ensure,
     hosts         => $hosts,
-    metrics_port  => $port,
+    metrics_port       => $_port,
+    ssl                => $_ssl,
     additional_metrics => $additional_metrics,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "npwalker/pe_metric_curl_cron_jobs",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "author": "npwalker",
   "summary": "A Puppet module for gathering metrics from PE components",
   "license": "Apache-2.0",


### PR DESCRIPTION
Prior to this commit, we'd connect to puppetdb over https and
not verify certs.  This doesn't work prior to 2016.4 because
puppetdb has metrics behind a cert whitelist.

After this commit, we connect to puppetdb over http if it is
running on the same node as the metrics script.  This avoids
the certificate issue.

For PE versions prior to 2016.4. you will not be able to collect
metrics on remote puppetdb systems.