### PR TITLE
Add utility script to collect metrics data

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Table of Contents
   * [Grepping for Metrics](#grepping-for-metrics)
     * [Puppetserver](#puppetserver)
     * [PuppetDB](#puppetdb)
+  * [Sharing Metrics data](#sharing-metrics-data)
 * [How to use](#how-to-use)
   * [Monolithic Install](#monolithic-install)
     * [Hiera data Example](#hiera-data-example)
@@ -104,7 +105,7 @@ puppetdb/127.0.0.1/20170404T171502Z.json:            "queue_depth": 0,
 
 PE 2016.5 and below:
 
-~~~
+```
 grep Cursor puppetdb/127.0.0.1/*.json
 puppetdb/127.0.0.1/20170404T171001Z.json:          "CursorMemoryUsage": 0,
 puppetdb/127.0.0.1/20170404T171001Z.json:          "CursorFull": false,
@@ -115,7 +116,20 @@ puppetdb/127.0.0.1/20170404T171502Z.json:          "CursorPercentUsage": 0,
 puppetdb/127.0.0.1/20170404T172002Z.json:          "CursorMemoryUsage": 0,
 puppetdb/127.0.0.1/20170404T172002Z.json:          "CursorFull": false,
 puppetdb/127.0.0.1/20170404T172002Z.json:          "CursorPercentUsage": 0,
-~~~
+```
+
+## Sharing Metrics data
+
+A common use of this module is for a support organization to assist Puppet Enterprise users in diagnosing problems by analyzing metrics. If working with a support organization or other outside party, you may need to create a metrics data tarball to transport and share your metrics data.
+
+The module creates a utility script on classified nodes to aid in preparing metrics data for transport.
+
+```
+[root@master ~]# /opt/puppetlabs/bin/puppet-metrics-collector create-tarball
+Metrics data tarball created at: /root/puppet-metrics-20170801T180338Z.tar.gz
+```
+
+The script will create a tarball in the current working directory with all the metrics information that's been collected, ready to transfer to an external support organization or assisting party.
 
 # How to use
 

--- a/README.md
+++ b/README.md
@@ -120,16 +120,16 @@ puppetdb/127.0.0.1/20170404T172002Z.json:          "CursorPercentUsage": 0,
 
 ## Sharing Metrics data
 
-A common use of this module is for a support organization to assist Puppet Enterprise users in diagnosing problems by analyzing metrics. If working with a support organization or other outside party, you may need to create a metrics data tarball to transport and share your metrics data.
+When working on performance tuning you may be asked to create a metrics data tarball to transport and share your metrics data.
 
-The module creates a utility script on classified nodes to aid in preparing metrics data for transport.
+The module provides a utility script, `puppet-metrics-collector` to aid in preparing metrics data for transport.
 
 ```
 [root@master ~]# /opt/puppetlabs/bin/puppet-metrics-collector create-tarball
 Metrics data tarball created at: /root/puppet-metrics-20170801T180338Z.tar.gz
 ```
 
-The script will create a tarball in the current working directory with all the metrics information that's been collected, ready to transfer to an external support organization or assisting party.
+The script creates a tarball containing your metrics in the current working directory.dd
 
 # How to use
 

--- a/files/puppet-metrics-collector
+++ b/files/puppet-metrics-collector
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+[ "$1" = "create-tarball" ] || { echo >&2 "ERROR: Usage: $0 create-tarball"; exit 1; }
+
+timestamp=$(date -u +"%Y%m%dT%H%M%SZ")
+tarball="puppet-metrics-${timestamp}.tar.gz"
+
+tar \
+  --exclude scripts \
+  --transform "s/pe_metric_curl_cron_jobs/puppet-metrics-${timestamp}/" \
+  -czf "${tarball}" \
+  -C /opt/puppetlabs \
+  pe_metric_curl_cron_jobs
+
+echo "Metrics data tarball created at: $(pwd)/${tarball}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,8 +21,9 @@ class pe_metric_curl_cron_jobs (
   Enum[present, absent] $cli_ensure            = 'present',
 ) {
   $scripts_dir = "${output_dir}/scripts"
+  $bin_dir = "${output_dir}/bin"
 
-  file { [ $output_dir, $scripts_dir ] :
+  file { [ $output_dir, $scripts_dir, $bin_dir] :
     ensure => directory,
   }
 
@@ -32,12 +33,22 @@ class pe_metric_curl_cron_jobs (
     source  => 'puppet:///modules/pe_metric_curl_cron_jobs/tk_metrics'
   }
 
-  file { '/opt/puppetlabs/bin/puppet-metrics-collector':
+  file { "${bin_dir}/puppet-metrics-collector":
     ensure => $cli_ensure,
     owner  => 'root',
     group  => 'root',
     mode   => '0755',
     source => 'puppet:///modules/pe_metric_curl_cron_jobs/puppet-metrics-collector',
+  }
+
+  $symlink_ensure = $cli_ensure ? {
+    'absent'  => 'absent',
+    'present' => 'symlink',
+  }
+
+  file { "/opt/puppetlabs/bin/puppet-metrics-collector":
+    ensure => $symlink_ensure,
+    target => "${bin_dir}/puppet-metrics-collector",
   }
 
   include pe_metric_curl_cron_jobs::puppetserver

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ class pe_metric_curl_cron_jobs (
   String        $activemq_metrics_ensure       = 'absent',
   Array[String] $activemq_hosts                = [ '127.0.0.1' ],
   Integer       $activemq_port                 = 8161,
+  Enum[present, absent] $cli_ensure            = 'present',
 ) {
   $scripts_dir = "${output_dir}/scripts"
 
@@ -29,6 +30,14 @@ class pe_metric_curl_cron_jobs (
     ensure  => present,
     mode    => '0744',
     source  => 'puppet:///modules/pe_metric_curl_cron_jobs/tk_metrics'
+  }
+
+  file { '/opt/puppetlabs/bin/puppet-metrics-collector':
+    ensure => $cli_ensure,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+    source => 'puppet:///modules/pe_metric_curl_cron_jobs/puppet-metrics-collector',
   }
 
   include pe_metric_curl_cron_jobs::puppetserver

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,11 +34,13 @@ class pe_metric_curl_cron_jobs (
   }
 
   file { "${bin_dir}/puppet-metrics-collector":
-    ensure => $cli_ensure,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0755',
-    source => 'puppet:///modules/pe_metric_curl_cron_jobs/puppet-metrics-collector',
+    ensure  => $cli_ensure,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+    content => epp('pe_metric_curl_cron_jobs/puppet-metrics-collector.epp', {
+      'output_dir' => $output_dir,
+    }),
   }
 
   $symlink_ensure = $cli_ensure ? {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,10 +18,10 @@ class pe_metric_curl_cron_jobs (
   String        $activemq_metrics_ensure       = 'absent',
   Array[String] $activemq_hosts                = [ '127.0.0.1' ],
   Integer       $activemq_port                 = 8161,
-  Enum[present, absent] $cli_ensure            = 'present',
+  Boolean       $symlink_puppet_metrics_collector = true,
 ) {
   $scripts_dir = "${output_dir}/scripts"
-  $bin_dir = "${output_dir}/bin"
+  $bin_dir     = "${output_dir}/bin"
 
   file { [ $output_dir, $scripts_dir, $bin_dir] :
     ensure => directory,
@@ -29,12 +29,12 @@ class pe_metric_curl_cron_jobs (
 
   file { "${scripts_dir}/tk_metrics" :
     ensure  => present,
-    mode    => '0744',
+    mode    => '0755',
     source  => 'puppet:///modules/pe_metric_curl_cron_jobs/tk_metrics'
   }
 
   file { "${bin_dir}/puppet-metrics-collector":
-    ensure  => $cli_ensure,
+    ensure  => file,
     owner   => 'root',
     group   => 'root',
     mode    => '0755',
@@ -43,9 +43,9 @@ class pe_metric_curl_cron_jobs (
     }),
   }
 
-  $symlink_ensure = $cli_ensure ? {
-    'absent'  => 'absent',
-    'present' => 'symlink',
+  $symlink_ensure = $symlink_puppet_metrics_collector ? {
+    false  => 'absent',
+    true   => 'symlink',
   }
 
   file { "/opt/puppetlabs/bin/puppet-metrics-collector":

--- a/templates/puppet-metrics-collector.epp
+++ b/templates/puppet-metrics-collector.epp
@@ -1,15 +1,23 @@
+<%- | String $output_dir,
+| -%>
 #!/bin/bash
+
 
 [ "$1" = "create-tarball" ] || { echo >&2 "ERROR: Usage: $0 create-tarball"; exit 1; }
 
 timestamp=$(date -u +"%Y%m%dT%H%M%SZ")
 tarball="puppet-metrics-${timestamp}.tar.gz"
 
+output_dir="<%= $output_dir %>"
+cwd=$(dirname "${output_dir}")
+target=$(basename "${output_dir}")
+
 tar \
   --exclude scripts \
-  --transform "s/pe_metric_curl_cron_jobs/puppet-metrics-${timestamp}/" \
+  --exclude bin \
+  --transform "s/${target}/puppet-metrics-${timestamp}/" \
   -czf "${tarball}" \
-  -C /opt/puppetlabs \
-  pe_metric_curl_cron_jobs
+  -C "${cwd}" \
+  "${target}"
 
 echo "Metrics data tarball created at: $(pwd)/${tarball}"


### PR DESCRIPTION
The purpose of this utility is to enable assist and support operations.
This commit adds a script which streamlines the user experience of
collecting and submitting metrics data for analysis.

Fixes #40