### PR TITLE
Sort hosts before writing them to a file

### DIFF
--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -22,7 +22,7 @@ define pe_metric_curl_cron_jobs::pe_metric (
   }
 
   $config_hash = {
-    'hosts'              => $hosts,
+    'hosts'              => $hosts.sort(),
     'metrics_type'       => $metrics_type,
     'metrics_port'       => $metrics_port,
     'additional_metrics' => $additional_metrics,


### PR DESCRIPTION
The hosts might be generated in a non-deterministic order (e.g. from PuppetDB). If that's the case, then the configuration file they're written to will change every run.

This ensures that they are always written consistently and avoids spurious change reports.