### PR TITLE
Exit tidy script on error

### DIFF
--- a/templates/tidy_cron.epp
+++ b/templates/tidy_cron.epp
@@ -3,6 +3,9 @@
       Integer $retention_days,
 | -%>
 #!/bin/sh
+
+set -e
+
 DIR='<%= $metrics_output_dir %>';
 METRICS_TYPE='<%= $metrics_type %>';
 RETENTION_DAYS=<%= $retention_days %>;


### PR DESCRIPTION
If the tidy script encounters an error, it will now exit with a failure. This is particularly important because it `cd`s into a directory and then deletes everything that isn't bzipped. If the `cd` fails, then it will delete everything in current working directory.