### PR TITLE
Use gzip in tidy instead of bzip2 for compatibility

### DIFF
--- a/templates/tidy_cron.epp
+++ b/templates/tidy_cron.epp
@@ -12,7 +12,7 @@ find "$DIR" -type f -ctime +$RETENTION_DAYS -delete
 
 #compress files
 cd "$DIR"
-find . -type f ! -name "*.bz2" > "$DIR.tmp";
-xargs -a "$DIR.tmp" tar -jcf "$DIR/$METRICS_TYPE-$(date +%Y.%m.%d.%H.%M.%S).tar.bz2" 2>/dev/null;
-xargs -a "$DIR.tmp" rm ;
-rm "$DIR.tmp";
+find . -type f -not -name "*.gz" -a -not -name "*.bz2" > "$DIR.tmp"
+xargs -a "$DIR.tmp" tar -zcf "$DIR/$METRICS_TYPE-$(date +%Y.%m.%d.%H.%M.%S).tar.gz"
+xargs -a "$DIR.tmp" rm
+rm "$DIR.tmp"


### PR DESCRIPTION
bzip2 isn't installed by default on CentOS 7. (!)

This also removes the error suppresion on tar, which improves debuggability.

Also, "!" is a shell special character. This switches to "-not", though it probably doesn't matter since it's non interactive.