### PR TITLE
Add PuppetDB sync metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Minor Release 4.6.0
+
+## Improvements:
+ - Add PuppetDB HA Metrics
+   - [PR #46](https://github.com/npwalker/pe_metric_curl_cron_jobs/pull/46)
+
 # Minor Release 4.5.0
 
 ## Improvements:

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -140,10 +140,32 @@ class pe_metric_curl_cron_jobs::puppetdb (
       'url'  => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.Wait' },
   ]
 
+  $ha_sync_metrics = [
+    { 'name' => 'ha_last-sync-succeeded',
+      'url'  => 'puppetlabs.puppetdb.ha:name=last-sync-succeeded' },
+    { 'name' => 'ha_seconds-since-last-successful-sync',
+      'url'  => 'puppetlabs.puppetdb.ha:name=seconds-since-last-successful-sync' },
+    { 'name' => 'ha_failed-request-counter',
+      'url'  => 'puppetlabs.puppetdb.ha:name=failed-request-counter' },
+    { 'name' => 'ha_sync-duration',
+      'url'  => 'puppetlabs.puppetdb.ha:name=sync-duration' },
+    { 'name' => 'ha_catalogs-sync-duration',
+      'url'  => 'puppetlabs.puppetdb.ha:name=catalogs-sync-duration' },
+    { 'name' => 'ha_reports-sync-duration',
+      'url'  => 'puppetlabs.puppetdb.ha:name=reports-sync-duration' },
+    { 'name' => 'ha_factsets-sync-duration',
+      'url'  => 'puppetlabs.puppetdb.ha:name=factsets-sync-duration' },
+    { 'name' => 'ha_nodes-sync-duration',
+      'url'  => 'puppetlabs.puppetdb.ha:name=nodes-sync-duration' },
+    { 'name' => 'ha_record-transfer-duration',
+      'url'  => 'puppetlabs.puppetdb.ha:name=record-transfer-duration' },
+  ]
+
   $additional_metrics = $::pe_server_version ? {
-    /^2015./ => $activemq_metrics,
-    /^2016./ => $activemq_metrics + $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics,
-    default  => $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics,
+    /^2015\./ => $activemq_metrics,
+    /^2016\.[45]\./ => $activemq_metrics + $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics + $ha_sync_metrics,
+    /^2016\./ => $activemq_metrics + $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics,
+    default  => $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics + $ha_sync_metrics,
   }
 
   $_ssl = $hosts ? {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "npwalker/pe_metric_curl_cron_jobs",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "author": "npwalker",
   "summary": "A Puppet module for gathering metrics from PE components",
   "license": "Apache-2.0",


### PR DESCRIPTION
This patch adds metrics from the puppetlabs.puppetdb.ha JMX namespace to the
default list of additional metrics collected from PuppetDB for PE 2016.4 and
later.