### PR TITLE
Rename project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# Major Release 5.0.0
+
+This major release renames the project and obseletes deprecated parameters that
+had previously been preserved for backwards compatiblity. The new name of the
+project aligns it with the value it provides, and eliminates long incorrect
+technology references to its implementation from the name.
+
+## Changes
+ - Rename the project from "pe\_metric\_curl\_cron\_jobs" to "puppet\_metrics\_collector"
+ - Remove deprecated parameters
+   - puppet\_metrics\_collector::puppet\_server\_hosts (long deprecated in favor of puppet\_metrics\_collector::puppetserver\_hosts)
+   - puppet\_metrics\_collector::puppet\_server\_port (long deprecated in favor of puppet\_metrics\_collector::puppetserver\_port)
+
 # Minor Release 4.6.0
 
 ## Improvements:

--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@ By default, the module tracks the metrics coming from the status endpoint on Pup
 
 ## Directory layout
 
-You have a new directory `/opt/puppetlabs/pe_metric_curl_cron_jobs` that has one directory per component  (Puppet Server, PuppetDB, or ActiveMQ).  Each component has one directory per host that metrics are gathered from.  Each host directory contains one JSON file collected every 5 minutes by default.  Once per day the metrics for each component are compressed for every host and saved in the root of that component's directory.
+You have a new directory `/opt/puppetlabs/puppet_metrics_collector` that has one directory per component  (Puppet Server, PuppetDB, or ActiveMQ).  Each component has one directory per host that metrics are gathered from.  Each host directory contains one JSON file collected every 5 minutes by default.  Once per day the metrics for each component are compressed for every host and saved in the root of that component's directory.
 
 Here's an example:
 
 ~~~
-/opt/puppetlabs/pe_metric_curl_cron_jobs/puppetserver
+/opt/puppetlabs/puppet_metrics_collector/puppetserver
 ├── 127.0.0.1
 │   ├── 20170404T020001Z.json
 │   ├── ...
 │   ├── 20170404T170501Z.json
 │   └── 20170404T171001Z.json
 └── puppetserver-2017.04.04.02.00.01.tar.bz2
-/opt/puppetlabs/pe_metric_curl_cron_jobs/puppetdb
+/opt/puppetlabs/puppet_metrics_collector/puppetdb
 └── 127.0.0.1
 │   ├── 20170404T020001Z.json
 │   ├── ...
@@ -67,9 +67,9 @@ Example:
 crontab -l
 ...
 # Puppet Name: puppetserver_metrics_collection
-*/5 * * * * /opt/puppetlabs/pe_metric_curl_cron_jobs/scripts/puppetserver_metrics
+*/5 * * * * /opt/puppetlabs/puppet_metrics_collector/scripts/puppetserver_metrics
 # Puppet Name: puppetserver_metrics_tidy
-0 2 * * * /opt/puppetlabs/pe_metric_curl_cron_jobs/scripts/puppetserver_metrics_tidy
+0 2 * * * /opt/puppetlabs/puppet_metrics_collector/scripts/puppetserver_metrics_tidy
 ~~~
 
 ## Grepping for Metrics
@@ -77,7 +77,7 @@ crontab -l
 You can get useful information with a grep like the one below run from inside of the directory containing the metrics files.  Since the metrics are compressed every night you can only grep metrics for the current day.  If you'd like to grep over a longer period of time you should decompress the compressed tarballs into `/tmp` and investigate further.
 
 ~~~
-cd /opt/puppetlabs/pe_metric_curl_cron_jobs
+cd /opt/puppetlabs/puppet_metrics_collector
 grep <metric_name> <component_name>/127.0.0.1/*.json
 ~~~
 
@@ -133,9 +133,9 @@ The script creates a tarball containing your metrics in the current working dire
 
 # How to use
 
-Install the module with `puppet module install npwalker-pe_metric_curl_cron_jobs` or add it to your Puppetfile.
+Install the module with `puppet module install npwalker-puppet_metrics_collector` or add it to your Puppetfile.
 
-To start data collection you will need to classify your puppet master with the `pe_metric_curl_cron_jobs` class using your preferred classification method.
+To start data collection you will need to classify your puppet master with the `puppet_metrics_collector` class using your preferred classification method.
 
 The following examples show how to configure the parameters to work in different setups but we assume you will always classify on the node that is the CA master.  The preferred method is to `include` the module and then provide hiera
 data for the parameters.
@@ -149,7 +149,7 @@ None needed for a monolithic install
 ### Class Definition
 
 ~~~
-include pe_metric_curl_cron_jobs
+include puppet_metrics_collector
 ~~~
 
 ## Split Install ( Running on the Master )
@@ -157,14 +157,14 @@ include pe_metric_curl_cron_jobs
 ### Hiera data Example
 
 ~~~
-pe_metric_curl_cron_jobs::puppetdb_hosts:
+puppet_metrics_collector::puppetdb_hosts:
  - 'split-puppetdb.domain.com'
 ~~~
 
 ### Class Definition Example
 
 ~~~
-class { 'pe_metric_curl_cron_jobs':
+class { 'puppet_metrics_collector':
   puppetdb_hosts => ['split-puppetdb.domain.com']
 }
 ~~~
@@ -174,7 +174,7 @@ class { 'pe_metric_curl_cron_jobs':
 ### Hiera data Example
 
 ~~~
-pe_metric_curl_cron_jobs::puppetserver_hosts:
+puppet_metrics_collector::puppetserver_hosts:
  - 'master-1.domain.com'
  - 'compile-master-1.domain.com'
  - 'compile-master-2.domain.com'
@@ -183,7 +183,7 @@ pe_metric_curl_cron_jobs::puppetserver_hosts:
 ### Class Definition Example
 
 ~~~
-class { 'pe_metric_curl_cron_jobs':
+class { 'puppet_metrics_collector':
   puppetserver_hosts => [
     'master-1.domain.com',
     'compile-master-1.domain.com',
@@ -197,9 +197,9 @@ class { 'pe_metric_curl_cron_jobs':
 ### Hiera data Example
 
 ~~~
-pe_metric_curl_cron_jobs::puppetdb_hosts:
+puppet_metrics_collector::puppetdb_hosts:
  - 'split-puppetdb.domain.com'
-pe_metric_curl_cron_jobs::puppetserver_hosts:
+puppet_metrics_collector::puppetserver_hosts:
  - 'master-1.domain.com'
  - 'compile-master-1.domain.com'
  - 'compile-master-2.domain.com'
@@ -208,7 +208,7 @@ pe_metric_curl_cron_jobs::puppetserver_hosts:
 ### Class Definition Example
 
 ~~~
-class { 'pe_metric_curl_cron_jobs':
+class { 'puppet_metrics_collector':
   puppetdb_hosts => ['split-puppetdb.domain.com'],
   puppetserver_hosts => [
     'master-1.domain.com',
@@ -223,16 +223,16 @@ class { 'pe_metric_curl_cron_jobs':
 You can still use this module on PE 3.8 although you have to run it with the future parser and you want to use `/opt/puppet` instead of `/opt/puppetlabs`. If the [future parser](https://docs.puppet.com/puppet/3.8/experiments_future.html) is enabled in the environment or globally, the following can be put in the site.pp.
 
 ~~~
-class { 'pe_metric_curl_cron_jobs':
-  output_dir => '/opt/puppet/pe_metric_curl_cron_jobs'
+class { 'puppet_metrics_collector':
+  output_dir => '/opt/puppet/puppet_metrics_collector'
 }
 ~~~
 
 The module can be run in a one off run if the future parser is not enabled in the environment.
 
 ~~~
-puppet module install npwalker-pe_metric_curl_cron_jobs --modulepath /tmp;
-puppet apply -e "class { 'pe_metric_curl_cron_jobs' : output_dir => '/opt/puppet/pe_metric_curl_cron_jobs' }"  --modulepath /tmp --parser=future
+puppet module install npwalker-puppet_metrics_collector --modulepath /tmp;
+puppet apply -e "class { 'puppet_metrics_collector' : output_dir => '/opt/puppet/puppet_metrics_collector' }"  --modulepath /tmp --parser=future
 ~~~
 
 If you do not want to manage this long term and want to get it up and running quickly you can run it via puppet apply. Make sure the puppetlabs-stdlib module is installed. Refer to the other examples if you want to change other parameters.
@@ -242,8 +242,8 @@ If you do not want to manage this long term and want to get it up and running qu
 The module installation is the best way to utilize this module, but it can be run on a one off basis with the following command.
 
 ~~~
-puppet module install npwalker-pe_metric_curl_cron_jobs --modulepath /tmp;
-puppet apply -e "class { 'pe_metric_curl_cron_jobs': }" --modulepath /tmp;
+puppet module install npwalker-puppet_metrics_collector --modulepath /tmp;
+puppet apply -e "class { 'puppet_metrics_collector': }" --modulepath /tmp;
 ~~~
 
 ## Alternate Option for Multi-node Metrics Collection

--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@ By default, the module tracks the metrics coming from the status endpoint on Pup
 
 ## Directory layout
 
-You have a new directory `/opt/puppetlabs/puppet_metrics_collector` that has one directory per component  (Puppet Server, PuppetDB, or ActiveMQ).  Each component has one directory per host that metrics are gathered from.  Each host directory contains one JSON file collected every 5 minutes by default.  Once per day the metrics for each component are compressed for every host and saved in the root of that component's directory.
+You have a new directory `/opt/puppetlabs/puppet-metrics-collector` that has one directory per component  (Puppet Server, PuppetDB, or ActiveMQ).  Each component has one directory per host that metrics are gathered from.  Each host directory contains one JSON file collected every 5 minutes by default.  Once per day the metrics for each component are compressed for every host and saved in the root of that component's directory.
 
 Here's an example:
 
 ~~~
-/opt/puppetlabs/puppet_metrics_collector/puppetserver
+/opt/puppetlabs/puppet-metrics-collector/puppetserver
 ├── 127.0.0.1
 │   ├── 20170404T020001Z.json
 │   ├── ...
 │   ├── 20170404T170501Z.json
 │   └── 20170404T171001Z.json
 └── puppetserver-2017.04.04.02.00.01.tar.bz2
-/opt/puppetlabs/puppet_metrics_collector/puppetdb
+/opt/puppetlabs/puppet-metrics-collector/puppetdb
 └── 127.0.0.1
 │   ├── 20170404T020001Z.json
 │   ├── ...
@@ -67,9 +67,9 @@ Example:
 crontab -l
 ...
 # Puppet Name: puppetserver_metrics_collection
-*/5 * * * * /opt/puppetlabs/puppet_metrics_collector/scripts/puppetserver_metrics
+*/5 * * * * /opt/puppetlabs/puppet-metrics-collector/scripts/puppetserver_metrics
 # Puppet Name: puppetserver_metrics_tidy
-0 2 * * * /opt/puppetlabs/puppet_metrics_collector/scripts/puppetserver_metrics_tidy
+0 2 * * * /opt/puppetlabs/puppet-metrics-collector/scripts/puppetserver_metrics_tidy
 ~~~
 
 ## Grepping for Metrics
@@ -77,7 +77,7 @@ crontab -l
 You can get useful information with a grep like the one below run from inside of the directory containing the metrics files.  Since the metrics are compressed every night you can only grep metrics for the current day.  If you'd like to grep over a longer period of time you should decompress the compressed tarballs into `/tmp` and investigate further.
 
 ~~~
-cd /opt/puppetlabs/puppet_metrics_collector
+cd /opt/puppetlabs/puppet-metrics-collector
 grep <metric_name> <component_name>/127.0.0.1/*.json
 ~~~
 

--- a/lib/puppet/functions/puppet_metrics_collector/to_yaml.rb
+++ b/lib/puppet/functions/puppet_metrics_collector/to_yaml.rb
@@ -1,6 +1,6 @@
 require 'yaml'
 
-Puppet::Functions.create_function(:'pe_metric_curl_cron_jobs::to_yaml') do
+Puppet::Functions.create_function(:'puppet_metrics_collector::to_yaml') do
   dispatch :to_yaml do
     param 'Hash', :hash_or_array
   end

--- a/manifests/activemq.pp
+++ b/manifests/activemq.pp
@@ -1,14 +1,14 @@
-class pe_metric_curl_cron_jobs::activemq (
-  Integer       $collection_frequency = $::pe_metric_curl_cron_jobs::collection_frequency,
-  Integer       $retention_days       = $::pe_metric_curl_cron_jobs::retention_days,
-  String        $metrics_ensure       = $::pe_metric_curl_cron_jobs::activemq_metrics_ensure,
-  Array[String] $hosts                = $::pe_metric_curl_cron_jobs::activemq_hosts,
-  Integer       $port                 = $::pe_metric_curl_cron_jobs::activemq_port,
+class puppet_metrics_collector::activemq (
+  Integer       $collection_frequency = $puppet_metrics_collector::collection_frequency,
+  Integer       $retention_days       = $puppet_metrics_collector::retention_days,
+  String        $metrics_ensure       = $puppet_metrics_collector::activemq_metrics_ensure,
+  Array[String] $hosts                = $puppet_metrics_collector::activemq_hosts,
+  Integer       $port                 = $puppet_metrics_collector::activemq_port,
 ) {
-  $scripts_dir = $::pe_metric_curl_cron_jobs::scripts_dir
+  $scripts_dir = $::puppet_metrics_collector::scripts_dir
 
-  Pe_metric_curl_cron_jobs::Pe_metric {
-    output_dir     => $::pe_metric_curl_cron_jobs::output_dir,
+  Puppet_metrics_collector::Pe_metric {
+    output_dir     => $::puppet_metrics_collector::output_dir,
     scripts_dir    => $scripts_dir,
     cron_minute    => "*/${collection_frequency}",
     retention_days => $retention_days,
@@ -55,10 +55,10 @@ class pe_metric_curl_cron_jobs::activemq (
   file { "${scripts_dir}/amq_metrics" :
     ensure  => present,
     mode    => '0744',
-    source  => 'puppet:///modules/pe_metric_curl_cron_jobs/amq_metrics',
+    source  => 'puppet:///modules/puppet_metrics_collector/amq_metrics',
   }
 
-  pe_metric_curl_cron_jobs::pe_metric { 'activemq' :
+  puppet_metrics_collector::pe_metric { 'activemq' :
     metric_ensure          => $metrics_ensure,
     hosts                  => $hosts,
     metrics_port           => $port,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,13 +1,9 @@
-class pe_metric_curl_cron_jobs (
-  # DEPRECATED API ==============================
-  Optional[String]        $puppet_server_metrics_ensure  = undef,
-  Optional[Array[String]] $puppet_server_hosts           = undef,
-  # CURRENT API =================================
-  String        $output_dir                    = '/opt/puppetlabs/pe_metric_curl_cron_jobs',
+class puppet_metrics_collector (
+  String        $output_dir                    = '/opt/puppetlabs/puppet-metrics-collector',
   Integer       $collection_frequency          = 5,
   Integer       $retention_days                = 90,
-  String        $puppetserver_metrics_ensure   = pick($pe_metric_curl_cron_jobs::puppet_server_metrics_ensure, 'present'),
-  Array[String] $puppetserver_hosts            = pick($pe_metric_curl_cron_jobs::puppet_server_hosts, [ '127.0.0.1' ]),
+  String        $puppetserver_metrics_ensure   = present,
+  Array[String] $puppetserver_hosts            = [ '127.0.0.1' ],
   Integer       $puppetserver_port             = 8140,
   String        $puppetdb_metrics_ensure       = 'present',
   Array[String] $puppetdb_hosts                = [ '127.0.0.1' ],
@@ -30,7 +26,7 @@ class pe_metric_curl_cron_jobs (
   file { "${scripts_dir}/tk_metrics" :
     ensure  => present,
     mode    => '0755',
-    source  => 'puppet:///modules/pe_metric_curl_cron_jobs/tk_metrics'
+    source  => 'puppet:///modules/puppet_metrics_collector/tk_metrics'
   }
 
   file { "${bin_dir}/puppet-metrics-collector":
@@ -38,7 +34,7 @@ class pe_metric_curl_cron_jobs (
     owner   => 'root',
     group   => 'root',
     mode    => '0755',
-    content => epp('pe_metric_curl_cron_jobs/puppet-metrics-collector.epp', {
+    content => epp('puppet_metrics_collector/puppet-metrics-collector.epp', {
       'output_dir' => $output_dir,
     }),
   }
@@ -53,20 +49,8 @@ class pe_metric_curl_cron_jobs (
     target => "${bin_dir}/puppet-metrics-collector",
   }
 
-  include pe_metric_curl_cron_jobs::puppetserver
-
-  include pe_metric_curl_cron_jobs::puppetdb
-
-  include pe_metric_curl_cron_jobs::orchestrator
-
-  include pe_metric_curl_cron_jobs::activemq
-
-  # Emit deprecation warnings if necessary
-  if ($puppet_server_metrics_ensure != undef) {
-    warning('Using deprecated parameter pe_metric_curl_cron_jobs::puppet_server_metrics_ensure! please use pe_metric_curl_cron_jobs::puppetserver_metrics_ensure instead.')
-  }
-  if ($puppet_server_hosts != undef) {
-    warning('Using deprecated parameter pe_metric_curl_cron_jobs::puppet_server_hosts! please use pe_metric_curl_cron_jobs::puppetserver_hosts instead.')
-  }
-
+  include puppet_metrics_collector::puppetserver
+  include puppet_metrics_collector::puppetdb
+  include puppet_metrics_collector::orchestrator
+  include puppet_metrics_collector::activemq
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,4 +53,17 @@ class puppet_metrics_collector (
   include puppet_metrics_collector::puppetdb
   include puppet_metrics_collector::orchestrator
   include puppet_metrics_collector::activemq
+
+  # LEGACY CLEANUP
+  # This exec resource exists to clean up old metrics directories created by
+  # the module before it was renamed.
+  $legacy_dir      = '/opt/puppetlabs/pe_metric_curl_cron_jobs'
+  $safe_output_dir = shellquote($output_dir)
+
+  exec { "migrate ${legacy_dir} directory":
+    path    => '/bin:/usr/bin',
+    command => "mv ${legacy_dir} ${safe_output_dir}",
+    onlyif  => "[ ! -e ${safe_output_dir} -a -e ${legacy_dir} ]",
+    before  => File[$output_dir],
+  }
 }

--- a/manifests/orchestrator.pp
+++ b/manifests/orchestrator.pp
@@ -1,18 +1,18 @@
-class pe_metric_curl_cron_jobs::orchestrator (
-  Integer       $collection_frequency = $::pe_metric_curl_cron_jobs::collection_frequency,
-  Integer       $retention_days       = $::pe_metric_curl_cron_jobs::retention_days,
-  String        $metrics_ensure       = $::pe_metric_curl_cron_jobs::orchestrator_metrics_ensure,
-  Array[String] $hosts                = $::pe_metric_curl_cron_jobs::orchestrator_hosts,
-  Integer       $port                 = $::pe_metric_curl_cron_jobs::orchestrator_port,
+class puppet_metrics_collector::orchestrator (
+  Integer       $collection_frequency = $puppet_metrics_collector::collection_frequency,
+  Integer       $retention_days       = $puppet_metrics_collector::retention_days,
+  String        $metrics_ensure       = $puppet_metrics_collector::orchestrator_metrics_ensure,
+  Array[String] $hosts                = $puppet_metrics_collector::orchestrator_hosts,
+  Integer       $port                 = $puppet_metrics_collector::orchestrator_port,
 ) {
-  Pe_metric_curl_cron_jobs::Pe_metric {
-    output_dir     => $::pe_metric_curl_cron_jobs::output_dir,
-    scripts_dir    => $::pe_metric_curl_cron_jobs::scripts_dir,
+  Puppet_metrics_collector::Pe_metric {
+    output_dir     => $puppet_metrics_collector::output_dir,
+    scripts_dir    => $puppet_metrics_collector::scripts_dir,
     cron_minute    => "*/${collection_frequency}",
     retention_days => $retention_days,
   }
 
-  pe_metric_curl_cron_jobs::pe_metric { 'orchestrator' :
+  puppet_metrics_collector::pe_metric { 'orchestrator' :
     metric_ensure => $metrics_ensure,
     hosts         => $hosts,
     metrics_port  => $port,

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -1,4 +1,4 @@
-define pe_metric_curl_cron_jobs::pe_metric (
+define puppet_metrics_collector::pe_metric (
   Enum['absent', 'present'] $metric_ensure  = 'present',
   String                    $output_dir,
   String                    $scripts_dir,
@@ -34,7 +34,7 @@ define pe_metric_curl_cron_jobs::pe_metric (
   file { "${scripts_dir}/${metrics_type}_config.yaml" :
     ensure  => $metric_ensure,
     mode    => '0644',
-    content => $config_hash.pe_metric_curl_cron_jobs::to_yaml(),
+    content => $config_hash.puppet_metrics_collector::to_yaml(),
   }
 
   $script_file_name = "${scripts_dir}/${metric_script_file}"
@@ -51,7 +51,7 @@ define pe_metric_curl_cron_jobs::pe_metric (
   file { $metrics_tidy_script_path :
     ensure  => $metric_ensure,
     mode    => '0744',
-    content => epp('pe_metric_curl_cron_jobs/tidy_cron.epp',
+    content => epp('puppet_metrics_collector/tidy_cron.epp',
                    { 'metrics_output_dir' => $metrics_output_dir,
                      'metrics_type'       => $metrics_type,
                      'retention_days'     => $retention_days,

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -1,13 +1,13 @@
-class pe_metric_curl_cron_jobs::puppetdb (
-  Integer       $collection_frequency = $::pe_metric_curl_cron_jobs::collection_frequency,
-  Integer       $retention_days       = $::pe_metric_curl_cron_jobs::retention_days,
-  String        $metrics_ensure       = $::pe_metric_curl_cron_jobs::puppetdb_metrics_ensure,
-  Array[String] $hosts                = $::pe_metric_curl_cron_jobs::puppetdb_hosts,
-  Integer       $port                 = $::pe_metric_curl_cron_jobs::puppetdb_port,
+class puppet_metrics_collector::puppetdb (
+  Integer       $collection_frequency = $puppet_metrics_collector::collection_frequency,
+  Integer       $retention_days       = $puppet_metrics_collector::retention_days,
+  String        $metrics_ensure       = $puppet_metrics_collector::puppetdb_metrics_ensure,
+  Array[String] $hosts                = $puppet_metrics_collector::puppetdb_hosts,
+  Integer       $port                 = $puppet_metrics_collector::puppetdb_port,
 ) {
-  Pe_metric_curl_cron_jobs::Pe_metric {
-    output_dir     => $::pe_metric_curl_cron_jobs::output_dir,
-    scripts_dir    => $::pe_metric_curl_cron_jobs::scripts_dir,
+  Puppet_metrics_collector::Pe_metric {
+    output_dir     => $puppet_metrics_collector::output_dir,
+    scripts_dir    => $puppet_metrics_collector::scripts_dir,
     cron_minute    => "*/${collection_frequency}",
     retention_days => $retention_days,
   }
@@ -179,7 +179,7 @@ class pe_metric_curl_cron_jobs::puppetdb (
     $_port = $port
   }
 
-  pe_metric_curl_cron_jobs::pe_metric { 'puppetdb' :
+  puppet_metrics_collector::pe_metric { 'puppetdb' :
     metric_ensure => $metrics_ensure,
     hosts         => $hosts,
     metrics_port       => $_port,

--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -1,28 +1,21 @@
-class pe_metric_curl_cron_jobs::puppetserver (
-  Integer       $collection_frequency = $::pe_metric_curl_cron_jobs::collection_frequency,
-  Integer       $retention_days       = $::pe_metric_curl_cron_jobs::retention_days,
-  String        $metrics_ensure       = $::pe_metric_curl_cron_jobs::puppetserver_metrics_ensure,
-  Array[String] $hosts                = $::pe_metric_curl_cron_jobs::puppetserver_hosts,
-  Integer       $port                 = $::pe_metric_curl_cron_jobs::puppetserver_port,
+class puppet_metrics_collector::puppetserver (
+  Integer       $collection_frequency = $puppet_metrics_collector::collection_frequency,
+  Integer       $retention_days       = $puppet_metrics_collector::retention_days,
+  String        $metrics_ensure       = $puppet_metrics_collector::puppetserver_metrics_ensure,
+  Array[String] $hosts                = $puppet_metrics_collector::puppetserver_hosts,
+  Integer       $port                 = $puppet_metrics_collector::puppetserver_port,
 ) {
-  Pe_metric_curl_cron_jobs::Pe_metric {
-    output_dir     => $::pe_metric_curl_cron_jobs::output_dir,
-    scripts_dir    => $::pe_metric_curl_cron_jobs::scripts_dir,
+  Puppet_metrics_collector::Pe_metric {
+    output_dir     => $puppet_metrics_collector::output_dir,
+    scripts_dir    => $puppet_metrics_collector::scripts_dir,
     cron_minute    => "*/${collection_frequency}",
     retention_days => $retention_days,
   }
 
-  pe_metric_curl_cron_jobs::pe_metric { 'puppetserver' :
+  puppet_metrics_collector::pe_metric { 'puppetserver' :
     metric_ensure => $metrics_ensure,
     hosts         => $hosts,
     metrics_port  => $port,
   }
 
-  # DEPRECATION MECHANISMS
-  # Ensure remanants of cron jobs and files from older versions of this module
-  # are cleaned up.
-  pe_metric_curl_cron_jobs::pe_metric { 'puppet_server' :
-    metric_ensure => 'absent',
-    metrics_port  => 8140,
-  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,12 @@
 {
-  "name": "npwalker/pe_metric_curl_cron_jobs",
-  "version": "4.6.0",
+  "name": "npwalker/puppet_metrics_collector",
+  "version": "5.0.0",
   "author": "npwalker",
   "summary": "A Puppet module for gathering metrics from PE components",
   "license": "Apache-2.0",
-  "source": "https://github.com/npwalker/pe_metric_curl_cron_jobs",
-  "project_page": "https://github.com/npwalker/pe_metric_curl_cron_jobs",
-  "issues_url": "https://github.com/npwalker/pe_metric_curl_cron_jobs/issues",
+  "source": "https://github.com/npwalker/puppet_metrics_collector",
+  "project_page": "https://github.com/npwalker/puppet_metrics_collector",
+  "issues_url": "https://github.com/npwalker/puppet_metrics_collector/issues",
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 2.6.0 < 5.0.0"}
   ],


### PR DESCRIPTION
Long overdue. Aligns name to communicate value/purpose rather than (incorrect) implementation details. Changelog updated with commentary.